### PR TITLE
spiffe: stabilize TPM DevID attestation across system VMs

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -32,7 +32,8 @@ path = [
   "overlays/custom-packages/system76-scheduler/0001-fix-add-missing-loop-in-process-scheduler-refresh-ta.patch",
   "modules/secureboot/keys/*",
   "modules/hardware/passthrough/pci-acs-override/0001-pci-add-pcie_acs_override-for-pci-passthrough.patch",
-  "overlays/custom-packages/systemd/0001-pam_systemd_home-Use-PAM_TEXT_INFO-for-token-prompts.patch"
+  "overlays/custom-packages/systemd/0001-pam_systemd_home-Use-PAM_TEXT_INFO-for-token-prompts.patch",
+  "overlays/custom-packages/spire/0001-remove-cloud-components-to-reduce-memory-footprint.patch"
 ]
 
 [[annotations]]

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -123,6 +123,32 @@ rec {
         };
         tpmAttestation = {
           enable = mkEnableOption "TPM DevID node attestation for system VMs";
+          endorsementCaCerts = mkOption {
+            type = types.listOf types.path;
+            default = [ ];
+            description = ''
+              TPM manufacturer endorsement CA certs (PEM files).
+              Deprecated: use endorsementCaBundle instead.
+              Kept for backward compatibility.
+            '';
+          };
+          endorsementCaBundle = mkOption {
+            type = types.str;
+            default = "";
+            description = ''
+              Combined PEM file with all TPM manufacturer endorsement CAs.
+              Populated from tpm-endorsement.nix wiring module (points to all.pem).
+              Used by SPIRE server as endorsement_ca_path.
+            '';
+          };
+          endorsementCaVendors = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description = ''
+              Expected TPM vendor names (advisory, for warning on mismatch).
+              Populated from hardware definition.
+            '';
+          };
         };
       };
 

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -103,6 +103,29 @@ rec {
       # IDS VM specific settings
       idsvm.mitmproxy.enable = mkEnableOption "MITM proxy in IDS VM for traffic inspection";
 
+      # SPIFFE/SPIRE identity framework
+      spiffe = {
+        enable = mkEnableOption "SPIFFE/SPIRE identity framework";
+        trustDomain = mkOption {
+          type = types.str;
+          default = "ghaf.internal";
+          description = "SPIFFE trust domain used by SPIRE";
+        };
+        serverPort = mkOption {
+          type = types.port;
+          default = 8081;
+          description = "SPIRE server bind port";
+        };
+        serverVm = mkOption {
+          type = types.str;
+          default = "admin-vm";
+          description = "VM that runs the SPIRE server";
+        };
+        tpmAttestation = {
+          enable = mkEnableOption "TPM DevID node attestation for system VMs";
+        };
+      };
+
       # Platform information (populated from host config)
       platform = {
         buildSystem = mkOption {
@@ -304,11 +327,16 @@ rec {
       };
 
       storage = {
-        encryption.enable = false;
+        encryption.enable = true;
         storeOnDisk = false;
       };
 
       graphics.boot.enable = true;
+
+      spiffe = {
+        enable = true;
+        tpmAttestation.enable = true;
+      };
 
       shm.enable = false;
       idsvm.mitmproxy.enable = false;
@@ -383,6 +411,11 @@ rec {
 
       graphics.boot.enable = true;
 
+      spiffe = {
+        enable = true;
+        tpmAttestation.enable = true;
+      };
+
       shm.enable = false;
       idsvm.mitmproxy.enable = false;
 
@@ -452,6 +485,11 @@ rec {
       storage = {
         encryption.enable = false;
         storeOnDisk = false;
+      };
+
+      spiffe = {
+        enable = false;
+        tpmAttestation.enable = false;
       };
 
       shm.enable = false;

--- a/modules/common/security/default.nix
+++ b/modules/common/security/default.nix
@@ -9,6 +9,7 @@
     ./disk-encryption.nix
     ./fail2ban.nix
     ./pwquality.nix
+    ./spiffe
     ./ssh-tarpit
     ./fleet
     ../../secureboot/secureboot.nix

--- a/modules/common/security/spiffe/agent.nix
+++ b/modules/common/security/spiffe/agent.nix
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPIRE Agent Module
+#
+# Runs a SPIRE agent on each VM. Supports two attestation modes:
+# - join_token: for app VMs (emulated TPM, no hardware root)
+# - tpm_devid: for system VMs with hardware TPM passthrough
+#
+# The attestation mode is selected based on cfg.attestationMode.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.agent;
+
+  useTpmDevid = cfg.attestationMode == "tpm_devid";
+
+  agentConf = ''
+    agent {
+      data_dir = "${cfg.dataDir}"
+      log_level = "${cfg.logLevel}"
+      server_address = "${cfg.serverAddress}"
+      server_port = ${toString cfg.serverPort}
+      trust_domain = "${cfg.trustDomain}"
+      trust_bundle_path = "${cfg.trustBundlePath}"
+      socket_path = "${cfg.socketPath}"
+  ''
+  + lib.optionalString (!useTpmDevid) ''
+    join_token_file = "${cfg.joinTokenFile}"
+  ''
+  + ''
+    }
+
+    plugins {
+  ''
+  + (
+    if useTpmDevid then
+      ''
+        NodeAttestor "tpm_devid" {
+          plugin_data {
+            devid_cert_path = "${cfg.tpmDevid.certPath}"
+            devid_priv_path = "${cfg.tpmDevid.privPath}"
+            devid_pub_path = "${cfg.tpmDevid.pubPath}"
+          }
+        }
+      ''
+    else
+      ''
+        NodeAttestor "join_token" {
+          plugin_data {}
+        }
+      ''
+  )
+  + ''
+
+      WorkloadAttestor "unix" {
+        plugin_data {}
+      }
+
+      KeyManager "disk" {
+        plugin_data {
+          directory = "${cfg.dataDir}/keys"
+        }
+      }
+    }
+  '';
+in
+{
+  _file = ./agent.nix;
+
+  options.ghaf.security.spiffe.agent = {
+    enable = lib.mkEnableOption "SPIRE agent";
+
+    trustDomain = lib.mkOption {
+      type = lib.types.str;
+      default = "ghaf.internal";
+      description = "SPIFFE trust domain expected from the server";
+    };
+
+    serverAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "SPIRE server address reachable from this VM";
+    };
+
+    serverPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8081;
+      description = "SPIRE server port";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/agent";
+      description = "SPIRE agent state directory";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "INFO";
+      description = "SPIRE agent log level";
+    };
+
+    trustBundlePath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/bundle.pem";
+      description = "Path to the SPIRE trust bundle PEM file";
+    };
+
+    joinTokenFile = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/tokens/agent.token";
+      description = "Path to a file containing a join token";
+    };
+
+    socketPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/run/spire/agent.sock";
+      description = "SPIRE Agent API socket path";
+    };
+
+    attestationMode = lib.mkOption {
+      type = lib.types.enum [
+        "join_token"
+        "tpm_devid"
+      ];
+      default = "join_token";
+      description = "Node attestation mode: join_token (app VMs) or tpm_devid (system VMs with TPM)";
+    };
+
+    tpmDevid = {
+      certPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/devid/devid.pem";
+        description = "Path to the DevID certificate";
+      };
+      privPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/devid/devid.priv";
+        description = "Path to the DevID TPM private blob";
+      };
+      pubPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/devid/devid.pub";
+        description = "Path to the DevID TPM public blob";
+      };
+    };
+
+    workloadApiGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "spiffe";
+      description = "Group allowed to access the SPIRE Agent API socket";
+    };
+
+    workloadApiUsers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "ghaf" ];
+      description = "Users added to workloadApiGroup for SPIRE Workload API access";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.spire ];
+
+    users.groups = {
+      spire = { };
+      "${cfg.workloadApiGroup}" = { };
+    };
+
+    users.users = {
+      spire = {
+        isSystemUser = true;
+        group = "spire";
+        extraGroups = lib.optionals useTpmDevid [
+          config.security.tpm2.tssGroup or "tss"
+        ];
+      };
+    }
+    // (lib.genAttrs cfg.workloadApiUsers (_: {
+      extraGroups = lib.mkAfter [ cfg.workloadApiGroup ];
+    }));
+
+    environment.etc."spire/agent.conf".text = agentConf;
+
+    # Own /run/spire via tmpfiles with group access for spiffe users
+    systemd.tmpfiles.rules = [
+      "d /run/spire 2750 spire ${cfg.workloadApiGroup} - -"
+    ];
+
+    systemd.services.spire-agent = {
+      description = "SPIRE Agent";
+      wantedBy = [ "multi-user.target" ];
+
+      requires = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+      ]
+      ++ lib.optionals useTpmDevid [ "spire-devid-provision.service" ];
+      wants = [ "network-online.target" ];
+      unitConfig = {
+        RequiresMountsFor = [ "/etc/common" ];
+      };
+
+      serviceConfig = {
+        PermissionsStartOnly = true;
+
+        User = "spire";
+        Group = "spire";
+
+        UMask = "007";
+
+        SupplementaryGroups = [
+          cfg.workloadApiGroup
+        ]
+        ++ lib.optionals useTpmDevid [
+          config.security.tpm2.tssGroup or "tss"
+        ];
+
+        ExecStart = "${pkgs.spire}/bin/spire-agent run -config /etc/spire/agent.conf";
+
+        StateDirectory = "spire/agent";
+        StateDirectoryMode = "0750";
+
+        Restart = "on-failure";
+        RestartSec = "2s";
+
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [
+          cfg.dataDir
+          "/run/spire"
+        ]
+        ++ lib.optionals useTpmDevid [
+          "/dev/tpmrm0"
+        ];
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/agent.nix
+++ b/modules/common/security/spiffe/agent.nix
@@ -188,6 +188,12 @@ in
       default = [ "ghaf" ];
       description = "Users added to workloadApiGroup for SPIRE Workload API access";
     };
+
+    commonMountPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common";
+      description = "Path to the common virtiofs mount (VMs use /etc/common, host uses /persist/common)";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -241,7 +247,7 @@ in
         "spire-devid-provision.service"
       ];
       unitConfig = {
-        RequiresMountsFor = [ "/etc/common" ];
+        RequiresMountsFor = [ cfg.commonMountPath ];
       };
 
       serviceConfig = {

--- a/modules/common/security/spiffe/agent.nix
+++ b/modules/common/security/spiffe/agent.nix
@@ -38,6 +38,7 @@ let
     plugins {
       NodeAttestor "tpm_devid" {
         plugin_data {
+          tpm_device_path = "/dev/tpm0"
           devid_cert_path = "${cfg.tpmDevid.certPath}"
           devid_priv_path = "${cfg.tpmDevid.privPath}"
           devid_pub_path = "${cfg.tpmDevid.pubPath}"
@@ -283,7 +284,7 @@ in
           "/run/spire"
         ]
         ++ lib.optionals useTpmDevid [
-          "/dev/tpmrm0"
+          "/dev/tpm0"
         ];
       };
     };

--- a/modules/common/security/spiffe/default.nix
+++ b/modules/common/security/spiffe/default.nix
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPIFFE/SPIRE Module Wrapper
+#
+# Imports server, agent, and TPM DevID modules.
+# Propagates shared options (trustDomain) to sub-modules.
+#
+{ config, lib, ... }:
+let
+  cfg = config.ghaf.security.spiffe;
+in
+{
+  _file = ./default.nix;
+
+  imports = [
+    ./server.nix
+    ./agent.nix
+    ./devid-ca.nix
+    ./devid-provision.nix
+  ];
+
+  options.ghaf.security.spiffe = {
+    enable = lib.mkEnableOption "SPIFFE/SPIRE support (identity control plane)";
+
+    trustDomain = lib.mkOption {
+      type = lib.types.str;
+      default = "ghaf.internal";
+      description = "SPIFFE trust domain used by SPIRE";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Propagate common defaults to server/agent
+    ghaf.security.spiffe.server.trustDomain = lib.mkDefault cfg.trustDomain;
+    ghaf.security.spiffe.agent.trustDomain = lib.mkDefault cfg.trustDomain;
+  };
+}

--- a/modules/common/security/spiffe/default.nix
+++ b/modules/common/security/spiffe/default.nix
@@ -18,6 +18,8 @@ in
     ./agent.nix
     ./devid-ca.nix
     ./devid-provision.nix
+    ./tpm-vendor-detect.nix
+    ./tpm-ek-verify.nix
   ];
 
   options.ghaf.security.spiffe = {

--- a/modules/common/security/spiffe/devid-ca.nix
+++ b/modules/common/security/spiffe/devid-ca.nix
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# DevID Certificate Authority Module (admin-vm)
+#
+# Manages a self-signed CA for issuing TPM DevID certificates.
+# The CA key lives on admin-vm's LUKS-encrypted storage (TPM-sealed).
+#
+# Workflow:
+# 1. On first boot: generates self-signed CA (RSA-4096)
+# 2. Publishes CA cert to /etc/common/spire/ca/ca.pem (virtiofs)
+# 3. Watches for CSR files from system VMs
+# 4. Signs each CSR, writes cert to /etc/common/spire/devid/certs/{vmName}.pem
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.devidCa;
+
+  inherit (cfg) caDir;
+  inherit (cfg) csrDir;
+  inherit (cfg) certDir;
+  inherit (cfg) caPublishPath;
+
+  spireDevidCaSetupApp = pkgs.writeShellApplication {
+    name = "spire-devid-ca-setup";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.openssl
+    ];
+    text = ''
+      mkdir -p "${caDir}" "${csrDir}" "${certDir}"
+      chmod 0700 "${caDir}"
+
+      CA_KEY="${caDir}/ca.key"
+      CA_CERT="${caDir}/ca.pem"
+
+      if [ ! -f "$CA_KEY" ]; then
+        echo "Generating DevID CA key pair..."
+        openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
+          -nodes -keyout "$CA_KEY" -out "$CA_CERT" \
+          -subj "/CN=Ghaf DevID CA/O=Ghaf/OU=SPIRE"
+        chmod 0600 "$CA_KEY"
+        chmod 0644 "$CA_CERT"
+        echo "DevID CA created at $CA_CERT"
+      else
+        echo "DevID CA already exists"
+      fi
+
+      # Publish CA cert to virtiofs for system VMs and SPIRE server
+      mkdir -p "$(dirname "${caPublishPath}")"
+      cp "$CA_CERT" "${caPublishPath}"
+      chmod 0644 "${caPublishPath}"
+      echo "Published CA cert to ${caPublishPath}"
+
+      # Create placeholder endorsement CA for SPIRE tpm_devid plugin.
+      # The tpm_devid NodeAttestor requires endorsement_ca_path (TPM manufacturer
+      # EK root cert). For production, replace with real manufacturer CAs
+      # (e.g. Infineon). This placeholder lets SPIRE server start; actual TPM
+      # DevID attestation will fail EK verification until real CAs are bundled.
+      ENDORSEMENT_CA="${caDir}/endorsement-ca.pem"
+      if [ ! -f "$ENDORSEMENT_CA" ]; then
+        cp "$CA_CERT" "$ENDORSEMENT_CA"
+        chmod 0644 "$ENDORSEMENT_CA"
+        echo "Created placeholder endorsement CA at $ENDORSEMENT_CA"
+      fi
+    '';
+  };
+
+  spireDevidSignApp = pkgs.writeShellApplication {
+    name = "spire-devid-sign";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.openssl
+      pkgs.inotify-tools
+    ];
+    text = ''
+      CA_KEY="${caDir}/ca.key"
+      CA_CERT="${caDir}/ca.pem"
+
+      if [ ! -f "$CA_KEY" ]; then
+        echo "ERROR: CA key not found at $CA_KEY" >&2
+        exit 1
+      fi
+
+      sign_csr() {
+        local csr="$1"
+        local base
+        base="$(basename "$csr" .csr)"
+        local out="${certDir}/''${base}.pem"
+
+        if [ -f "$out" ]; then
+          echo "Certificate already exists for $base, skipping"
+          return
+        fi
+
+        echo "Signing CSR for $base..."
+        openssl x509 -req -in "$csr" \
+          -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+          -days 365 -sha256 \
+          -out "$out"
+        chmod 0644 "$out"
+        echo "Signed certificate written to $out"
+      }
+
+      # Sign any existing CSRs first
+      for csr in "${csrDir}"/*.csr; do
+        [ -f "$csr" ] && sign_csr "$csr"
+      done
+
+      # Watch for new CSRs
+      echo "Watching ${csrDir} for new CSRs..."
+      inotifywait -m -e close_write -e moved_to "${csrDir}" --format '%f' | while read -r filename; do
+        if [[ "$filename" == *.csr ]]; then
+          sign_csr "${csrDir}/$filename"
+        fi
+      done
+    '';
+  };
+in
+{
+  _file = ./devid-ca.nix;
+
+  options.ghaf.security.spiffe.devidCa = {
+    enable = lib.mkEnableOption "DevID Certificate Authority for SPIRE TPM attestation";
+
+    caDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/ca";
+      description = "Directory for CA key and certificate (on encrypted storage)";
+    };
+
+    caPublishPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/ca/ca.pem";
+      description = "Path where CA cert is published (virtiofs, readable by VMs)";
+    };
+
+    csrDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/requests";
+      description = "Directory where system VMs submit CSR files (virtiofs)";
+    };
+
+    certDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/certs";
+      description = "Directory where signed DevID certs are placed (virtiofs)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.spire-devid-ca = {
+      description = "SPIRE DevID CA setup";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "spire-server.service" ];
+      after = [ "local-fs.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe spireDevidCaSetupApp;
+      };
+    };
+
+    systemd.services.spire-devid-sign = {
+      description = "SPIRE DevID CSR signer (watches for CSRs from system VMs)";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "spire-devid-ca.service"
+        "local-fs.target"
+      ];
+      requires = [ "spire-devid-ca.service" ];
+
+      serviceConfig = {
+        ExecStart = lib.getExe spireDevidSignApp;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/devid-ca.nix
+++ b/modules/common/security/spiffe/devid-ca.nix
@@ -56,18 +56,6 @@ let
       cp "$CA_CERT" "${caPublishPath}"
       chmod 0644 "${caPublishPath}"
       echo "Published CA cert to ${caPublishPath}"
-
-      # Create placeholder endorsement CA for SPIRE tpm_devid plugin.
-      # The tpm_devid NodeAttestor requires endorsement_ca_path (TPM manufacturer
-      # EK root cert). For production, replace with real manufacturer CAs
-      # (e.g. Infineon). This placeholder lets SPIRE server start; actual TPM
-      # DevID attestation will fail EK verification until real CAs are bundled.
-      ENDORSEMENT_CA="${caDir}/endorsement-ca.pem"
-      if [ ! -f "$ENDORSEMENT_CA" ]; then
-        cp "$CA_CERT" "$ENDORSEMENT_CA"
-        chmod 0644 "$ENDORSEMENT_CA"
-        echo "Created placeholder endorsement CA at $ENDORSEMENT_CA"
-      fi
     '';
   };
 

--- a/modules/common/security/spiffe/devid-ca.nix
+++ b/modules/common/security/spiffe/devid-ca.nix
@@ -63,12 +63,14 @@ let
     name = "spire-devid-sign";
     runtimeInputs = [
       pkgs.coreutils
+      pkgs.gnugrep
       pkgs.openssl
       pkgs.inotify-tools
     ];
     text = ''
       CA_KEY="${caDir}/ca.key"
       CA_CERT="${caDir}/ca.pem"
+      CA_SERIAL="${caDir}/ca.srl"
 
       if [ ! -f "$CA_KEY" ]; then
         echo "ERROR: CA key not found at $CA_KEY" >&2
@@ -80,32 +82,125 @@ let
         local base
         base="$(basename "$csr" .csr)"
         local out="${certDir}/''${base}.pem"
+        local tmp_out="''${out}.tmp"
 
         if [ -f "$out" ]; then
-          echo "Certificate already exists for $base, skipping"
-          return
+          if [ -s "$out" ]; then
+            echo "Certificate already exists for $base, skipping"
+            return
+          fi
+          echo "WARNING: Found empty certificate for $base, regenerating"
+          rm -f "$out"
+        fi
+
+        if [ ! -s "$csr" ]; then
+          echo "WARNING: CSR for $base is empty, skipping"
+          return 1
+        fi
+
+        if [ -f "$CA_SERIAL" ] && ! grep -Eq '^[0-9A-Fa-f]+$' "$CA_SERIAL"; then
+          echo "WARNING: Invalid CA serial file, recreating $CA_SERIAL"
+          rm -f "$CA_SERIAL"
         fi
 
         echo "Signing CSR for $base..."
-        openssl x509 -req -in "$csr" \
+        if ! openssl x509 -req -in "$csr" \
           -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+          -CAserial "$CA_SERIAL" \
           -days 365 -sha256 \
-          -out "$out"
+          -out "$tmp_out"; then
+          echo "ERROR: Failed to sign CSR for $base"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        if [ ! -s "$tmp_out" ]; then
+          echo "ERROR: Signed certificate for $base is empty"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        mv -f "$tmp_out" "$out"
         chmod 0644 "$out"
         echo "Signed certificate written to $out"
       }
 
-      # Sign any existing CSRs first
-      for csr in "${csrDir}"/*.csr; do
-        [ -f "$csr" ] && sign_csr "$csr"
-      done
+      sign_pub_request() {
+        local pub="$1"
+        local base
+        base="$(basename "$pub" .pub.pem)"
+        local out="${certDir}/''${base}.pem"
+        local tmp_out="''${out}.tmp"
 
-      # Watch for new CSRs
-      echo "Watching ${csrDir} for new CSRs..."
-      inotifywait -m -e close_write -e moved_to "${csrDir}" --format '%f' | while read -r filename; do
-        if [[ "$filename" == *.csr ]]; then
-          sign_csr "${csrDir}/$filename"
+        if [ -f "$out" ]; then
+          if [ -s "$out" ]; then
+            echo "Certificate already exists for $base, skipping"
+            return
+          fi
+          echo "WARNING: Found empty certificate for $base, regenerating"
+          rm -f "$out"
         fi
+
+        if [ ! -s "$pub" ]; then
+          echo "WARNING: Public key request for $base is empty, skipping"
+          return 1
+        fi
+
+        if ! openssl pkey -pubin -in "$pub" -noout >/dev/null 2>&1; then
+          echo "WARNING: Public key request for $base is invalid, skipping"
+          return 1
+        fi
+
+        if [ -f "$CA_SERIAL" ] && ! grep -Eq '^[0-9A-Fa-f]+$' "$CA_SERIAL"; then
+          echo "WARNING: Invalid CA serial file, recreating $CA_SERIAL"
+          rm -f "$CA_SERIAL"
+        fi
+
+        echo "Signing public key request for $base..."
+        if ! openssl x509 -new \
+          -force_pubkey "$pub" \
+          -set_subject "/CN=$base/O=Ghaf/OU=DevID" \
+          -CA "$CA_CERT" -CAkey "$CA_KEY" -CAcreateserial \
+          -CAserial "$CA_SERIAL" \
+          -days 365 -sha256 \
+          -out "$tmp_out"; then
+          echo "ERROR: Failed to sign public key request for $base"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        if [ ! -s "$tmp_out" ]; then
+          echo "ERROR: Signed certificate for $base is empty"
+          rm -f "$tmp_out"
+          return 1
+        fi
+
+        mv -f "$tmp_out" "$out"
+        chmod 0644 "$out"
+        echo "Signed certificate written to $out"
+      }
+
+      scan_pending_requests() {
+        local count=0
+        shopt -s nullglob
+        for pub in "${csrDir}"/*.pub.pem; do
+          count=$((count + 1))
+          sign_pub_request "$pub" || true
+        done
+        for csr in "${csrDir}"/*.csr; do
+          count=$((count + 1))
+          sign_csr "$csr" || true
+        done
+        shopt -u nullglob
+        echo "Request scan complete: found $count request(s)"
+      }
+
+      # Startup sweep + resilient inotify/poll loop.
+      # Polling fallback handles virtiofs/inotify event loss.
+      while true; do
+        scan_pending_requests
+        echo "Watching ${csrDir} for new requests (5s window)..."
+        inotifywait -q -t 5 -e close_write -e moved_to "${csrDir}" >/dev/null 2>&1 || true
       done
     '';
   };

--- a/modules/common/security/spiffe/devid-provision.nix
+++ b/modules/common/security/spiffe/devid-provision.nix
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# DevID Key Provisioning Module (system VMs with hardware TPM)
+#
+# On each system VM with TPM passthrough, this service:
+# 1. Creates an ephemeral TPM primary key
+# 2. Creates RSA-2048 signing key under it
+# 3. Saves key blobs to encrypted storage
+# 4. Generates a CSR
+# 5. Submits CSR to admin-vm via virtiofs
+# 6. Waits for signed certificate
+#
+# Key blobs are transient (no persistent TPM handles needed).
+# The SPIRE agent loads key blobs on demand.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.devidProvision;
+
+  spireDevidProvisionApp = pkgs.writeShellApplication {
+    name = "spire-devid-provision";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.tpm2-tools
+      pkgs.openssl
+    ];
+    text = ''
+      VM_NAME="${cfg.vmName}"
+      DEVID_DIR="${cfg.devidDir}"
+      CSR_DIR="${cfg.csrDir}"
+      CERT_DIR="${cfg.certDir}"
+
+      mkdir -p "$DEVID_DIR"
+      chmod 0700 "$DEVID_DIR"
+
+      PRIV_BLOB="$DEVID_DIR/devid.priv"
+      PUB_BLOB="$DEVID_DIR/devid.pub"
+      CERT_FILE="$DEVID_DIR/devid.pem"
+
+      # Check if key blobs already exist
+      if [ -f "$PRIV_BLOB" ] && [ -f "$PUB_BLOB" ]; then
+        echo "DevID key blobs already exist for $VM_NAME"
+
+        # Still need to ensure we have a cert
+        if [ -f "$CERT_FILE" ]; then
+          echo "DevID cert already exists, skipping provisioning"
+          exit 0
+        fi
+
+        echo "Key blobs exist but no cert yet, waiting for cert..."
+      else
+        echo "Generating DevID key for $VM_NAME..."
+
+        # Create ephemeral primary key
+        tpm2_createprimary -C owner -c "$DEVID_DIR/primary.ctx" -Q
+
+        # Create RSA-2048 signing key under the primary
+        tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa:sha256 \
+          -u "$PUB_BLOB" -r "$PRIV_BLOB" -Q
+
+        # Load the key to get a context for CSR generation
+        tpm2_load -C "$DEVID_DIR/primary.ctx" \
+          -u "$PUB_BLOB" -r "$PRIV_BLOB" \
+          -c "$DEVID_DIR/devid.ctx" -Q
+
+        # Extract the public key in PEM format for CSR generation
+        tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f pem -o "$DEVID_DIR/devid-pub.pem" -Q
+
+        # Generate CSR using openssl with the extracted public key
+        # Note: We create a CSR with just the public key; the TPM holds the private key
+        openssl req -new -key "$DEVID_DIR/devid-pub.pem" \
+          -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
+          -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || {
+          # If openssl refuses (needs private key for signing), create a self-signed
+          # placeholder CSR using tpm2-tools + openssl collaboration
+          echo "Generating CSR via TPM-backed key..."
+          # Create a minimal CSR data structure and sign with TPM
+          openssl req -new -newkey rsa:2048 -nodes \
+            -keyout /dev/null -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
+            -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || true
+        }
+
+        # Clean up transient context files
+        rm -f "$DEVID_DIR/primary.ctx" "$DEVID_DIR/devid.ctx"
+
+        chmod 0600 "$PRIV_BLOB" "$PUB_BLOB"
+        echo "DevID key blobs created"
+
+        # Submit CSR to admin-vm via virtiofs
+        if [ -f "$DEVID_DIR/$VM_NAME.csr" ]; then
+          mkdir -p "$CSR_DIR"
+          cp "$DEVID_DIR/$VM_NAME.csr" "$CSR_DIR/$VM_NAME.csr"
+          echo "CSR submitted to $CSR_DIR/$VM_NAME.csr"
+        fi
+      fi
+
+      # Wait for signed cert from admin-vm
+      echo "Waiting for signed DevID certificate..."
+      for i in $(seq 1 120); do
+        if [ -f "$CERT_DIR/$VM_NAME.pem" ]; then
+          cp "$CERT_DIR/$VM_NAME.pem" "$CERT_FILE"
+          chmod 0644 "$CERT_FILE"
+          echo "DevID certificate received and stored at $CERT_FILE"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting for cert... ($i/120)"
+        fi
+        sleep 2
+      done
+
+      echo "WARNING: Timed out waiting for DevID certificate"
+      exit 1
+    '';
+  };
+in
+{
+  _file = ./devid-provision.nix;
+
+  options.ghaf.security.spiffe.devidProvision = {
+    enable = lib.mkEnableOption "DevID key provisioning for SPIRE TPM attestation";
+
+    vmName = lib.mkOption {
+      type = lib.types.str;
+      description = "Name of this VM (used in CSR CN and file paths)";
+    };
+
+    devidDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/devid";
+      description = "Directory for DevID key blobs and cert (on encrypted storage)";
+    };
+
+    csrDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/requests";
+      description = "Directory where CSR is submitted (virtiofs, admin-vm readable)";
+    };
+
+    certDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/devid/certs";
+      description = "Directory where signed certs are placed by admin-vm (virtiofs)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.spire-devid-provision = {
+      description = "SPIRE DevID key provisioning (TPM)";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "spire-agent.service" ];
+      after = [ "local-fs.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe spireDevidProvisionApp;
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/devid-provision.nix
+++ b/modules/common/security/spiffe/devid-provision.nix
@@ -35,6 +35,10 @@ let
       DEVID_DIR="${cfg.devidDir}"
       CSR_DIR="${cfg.csrDir}"
       CERT_DIR="${cfg.certDir}"
+      mkdir -p /run/tpm
+
+      # Provision through TPM resource manager device.
+      export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
 
       mkdir -p "$DEVID_DIR"
       chmod 0750 "$DEVID_DIR"
@@ -42,101 +46,183 @@ let
 
       PRIV_BLOB="$DEVID_DIR/devid.priv"
       PUB_BLOB="$DEVID_DIR/devid.pub"
+      PUB_PEM="$DEVID_DIR/devid-pub.pem"
       CERT_FILE="$DEVID_DIR/devid.pem"
+      TSS_PUB_BLOB="$DEVID_DIR/devid.tss.pub"
+      PUB_REQ_FILE="$CSR_DIR/$VM_NAME.pub.pem"
+
+      cleanup_contexts() {
+        if [ -f "$DEVID_DIR/devid.ctx" ]; then
+          timeout 5 tpm2_flushcontext "$DEVID_DIR/devid.ctx" -Q >/dev/null 2>&1 || true
+        fi
+        if [ -f "$DEVID_DIR/primary.ctx" ]; then
+          timeout 5 tpm2_flushcontext "$DEVID_DIR/primary.ctx" -Q >/dev/null 2>&1 || true
+        fi
+        rm -f "$DEVID_DIR/primary.ctx" "$DEVID_DIR/devid.ctx" "$TSS_PUB_BLOB"
+      }
+
+      normalize_private_blob() {
+        if [ ! -f "$PRIV_BLOB" ]; then
+          return
+        fi
+
+        local priv_size priv_prefix_hex priv_prefix
+        priv_size=$(wc -c < "$PRIV_BLOB")
+        priv_prefix_hex=$(od -An -tx1 -N2 "$PRIV_BLOB" 2>/dev/null | tr -d ' \n')
+
+        if [[ "$priv_prefix_hex" =~ ^[0-9a-fA-F]{4}$ ]] && [ "$priv_size" -gt 2 ]; then
+          priv_prefix=$((16#$priv_prefix_hex))
+        else
+          priv_prefix=""
+        fi
+
+        if [ -n "$priv_prefix" ] && [ $((priv_prefix + 2)) -eq "$priv_size" ]; then
+          echo "Converting DevID private blob from TPM2B_PRIVATE to TPM2_PRIVATE"
+          if ! dd if="$PRIV_BLOB" of="$PRIV_BLOB.raw" bs=1 skip=2 status=none 2>/dev/null; then
+            echo "Failed to normalize DevID private blob"
+            echo "Falling back to join_token attestation"
+            echo "normalize-private-failed" > /run/tpm/devid-status 2>/dev/null || true
+            rm -f "$PRIV_BLOB.raw"
+            exit 0
+          fi
+          mv -f "$PRIV_BLOB.raw" "$PRIV_BLOB"
+        fi
+      }
+
+      create_srk_primary() {
+        # Match SPIRE/go-tpm SRKTemplateHighRSA as closely as possible.
+        # Fallback keeps compatibility with older tpm2-tools variants.
+        if timeout 15 tpm2_createprimary -C owner \
+          -G rsa2048:null:aes128cfb -g sha256 \
+          -a "fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|decrypt|noda" \
+          -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null; then
+          return 0
+        fi
+
+        timeout 15 tpm2_createprimary -C owner -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null
+      }
 
       # Check if key blobs already exist
       if [ -f "$PRIV_BLOB" ] && [ -f "$PUB_BLOB" ]; then
+        PUB_HEAD=$(od -An -tx1 -N2 "$PUB_BLOB" 2>/dev/null | tr -d ' \n')
+        if [ "$PUB_HEAD" != "0001" ] && [ "$PUB_HEAD" != "0023" ]; then
+          echo "WARNING: Existing DevID public blob is not TPMT_PUBLIC, regenerating key blobs"
+          rm -f "$PRIV_BLOB" "$PUB_BLOB" "$PUB_PEM" "$CERT_FILE" "$TSS_PUB_BLOB"
+        fi
+      fi
+
+      if [ -f "$PRIV_BLOB" ] && [ -f "$PUB_BLOB" ]; then
+        normalize_private_blob
         echo "DevID key blobs already exist for $VM_NAME"
 
-        # Still need to ensure we have a cert
-        if [ -f "$CERT_FILE" ]; then
+        # Still need to ensure we have a valid cert
+        if [ -s "$CERT_FILE" ] && openssl x509 -in "$CERT_FILE" -noout >/dev/null 2>&1; then
           echo "DevID cert already exists, skipping provisioning"
           exit 0
+        fi
+        if [ -f "$CERT_FILE" ]; then
+          echo "WARNING: Existing DevID cert is empty/invalid, regenerating"
+          rm -f "$CERT_FILE"
+        fi
+
+        if [ -f "$PUB_PEM" ]; then
+          mkdir -p "$CSR_DIR"
+          cp "$PUB_PEM" "$PUB_REQ_FILE"
+          echo "Published DevID public key request to $PUB_REQ_FILE"
+        else
+          echo "WARNING: Missing $PUB_PEM for re-signing request"
         fi
 
         echo "Key blobs exist but no cert yet, waiting for cert..."
       else
         echo "Generating DevID key for $VM_NAME..."
 
-        # Wait for a TPM hierarchy to become accessible (max 60s).
-        # Prefer endorsement hierarchy for identity attestation.
+        # Wait for owner hierarchy access (max 60s).
         TPM_READY=0
-        TPM_HIERARCHY=""
         for attempt in $(seq 1 30); do
-          if tpm2_createprimary -C endorsement -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null; then
+          if create_srk_primary; then
             TPM_READY=1
-            TPM_HIERARCHY="endorsement"
             break
           fi
-          if tpm2_createprimary -C owner -c "$DEVID_DIR/primary.ctx" -Q 2>/dev/null; then
-            TPM_READY=1
-            TPM_HIERARCHY="owner"
-            break
-          fi
-          rm -f "$DEVID_DIR/primary.ctx"
-          echo "Waiting for TPM hierarchy... ($attempt/30)"
+          cleanup_contexts
+          echo "Waiting for TPM owner hierarchy... ($attempt/30)"
           sleep 2
         done
         if [ "$TPM_READY" -eq 0 ]; then
-          TPM_ERR=$(tpm2_createprimary -C endorsement -c "$DEVID_DIR/primary.ctx" -Q 2>&1) || true
-          rm -f "$DEVID_DIR/primary.ctx"
-          echo "No TPM hierarchy accessible after 60s: $TPM_ERR"
+          echo "TPM owner hierarchy inaccessible after 60s"
           echo "Falling back to join_token attestation"
-          echo "no-hierarchy" > /run/tpm/devid-status 2>/dev/null || true
+          echo "no-owner-hierarchy" > /run/tpm/devid-status 2>/dev/null || true
           exit 0
         fi
-        echo "Using $TPM_HIERARCHY hierarchy for DevID"
 
-        # Create RSA-2048 signing key under the primary
-        tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa:sha256 \
-          -u "$PUB_BLOB" -r "$PRIV_BLOB" -Q
+        KEY_CREATED=0
+        if tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa-sha256 \
+          -u "$TSS_PUB_BLOB" -r "$PRIV_BLOB" -c "$DEVID_DIR/devid.ctx" -Q 2>/dev/null; then
+          KEY_CREATED=1
+          echo "DevID key created with -G rsa2048:rsassa-sha256"
+        elif tpm2_create -C "$DEVID_DIR/primary.ctx" -G rsa2048:rsassa -g sha256 \
+          -u "$TSS_PUB_BLOB" -r "$PRIV_BLOB" -c "$DEVID_DIR/devid.ctx" -Q 2>/dev/null; then
+          KEY_CREATED=1
+          echo "DevID key created with -G rsa2048:rsassa -g sha256"
+        fi
+        if [ "$KEY_CREATED" -ne 1 ]; then
+          echo "Failed to create DevID key with supported tpm2_create syntaxes"
+          echo "Falling back to join_token attestation"
+          echo "keygen-failed" > /run/tpm/devid-status 2>/dev/null || true
+          cleanup_contexts
+          exit 0
+        fi
 
-        # Load the key to get a context for CSR generation
-        tpm2_load -C "$DEVID_DIR/primary.ctx" \
-          -u "$PUB_BLOB" -r "$PRIV_BLOB" \
-          -c "$DEVID_DIR/devid.ctx" -Q
+        READPUB_OK=0
+        for _ in 1 2 3; do
+          if tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f tpmt -o "$PUB_BLOB" -Q 2>/dev/null; then
+            READPUB_OK=1
+            break
+          fi
+          sleep 1
+        done
+        if [ "$READPUB_OK" -ne 1 ]; then
+          echo "Failed to export DevID TPMT_PUBLIC blob"
+          echo "Falling back to join_token attestation"
+          echo "readpublic-tpmt-failed" > /run/tpm/devid-status 2>/dev/null || true
+          cleanup_contexts
+          exit 0
+        fi
 
-        # Extract the public key in PEM format for CSR generation
-        tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f pem -o "$DEVID_DIR/devid-pub.pem" -Q
+        normalize_private_blob
 
-        # Generate CSR using openssl with the extracted public key
-        # Note: We create a CSR with just the public key; the TPM holds the private key
-        openssl req -new -key "$DEVID_DIR/devid-pub.pem" \
-          -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
-          -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || {
-          # If openssl refuses (needs private key for signing), create a self-signed
-          # placeholder CSR using tpm2-tools + openssl collaboration
-          echo "Generating CSR via TPM-backed key..."
-          # Create a minimal CSR data structure and sign with TPM
-          openssl req -new -newkey rsa:2048 -nodes \
-            -keyout /dev/null -subj "/CN=$VM_NAME/O=Ghaf/OU=DevID" \
-            -out "$DEVID_DIR/$VM_NAME.csr" 2>/dev/null || true
-        }
+        if ! tpm2_readpublic -c "$DEVID_DIR/devid.ctx" -f pem -o "$PUB_PEM" -Q 2>/dev/null; then
+          echo "Failed to export DevID public key"
+          echo "Falling back to join_token attestation"
+          echo "readpublic-failed" > /run/tpm/devid-status 2>/dev/null || true
+          cleanup_contexts
+          exit 0
+        fi
+
+        mkdir -p "$CSR_DIR"
+        cp "$PUB_PEM" "$PUB_REQ_FILE"
+        echo "Published DevID public key request to $PUB_REQ_FILE"
 
         # Clean up transient context files
-        rm -f "$DEVID_DIR/primary.ctx" "$DEVID_DIR/devid.ctx"
+        cleanup_contexts
 
         chown root:spire "$PRIV_BLOB" "$PUB_BLOB"
         chmod 0640 "$PRIV_BLOB" "$PUB_BLOB"
+        echo "ready" > /run/tpm/devid-status 2>/dev/null || true
         echo "DevID key blobs created"
-
-        # Submit CSR to admin-vm via virtiofs
-        if [ -f "$DEVID_DIR/$VM_NAME.csr" ]; then
-          mkdir -p "$CSR_DIR"
-          cp "$DEVID_DIR/$VM_NAME.csr" "$CSR_DIR/$VM_NAME.csr"
-          echo "CSR submitted to $CSR_DIR/$VM_NAME.csr"
-        fi
       fi
 
       # Wait for signed cert from admin-vm
       echo "Waiting for signed DevID certificate..."
       for i in $(seq 1 120); do
-        if [ -f "$CERT_DIR/$VM_NAME.pem" ]; then
+        if [ -s "$CERT_DIR/$VM_NAME.pem" ] && openssl x509 -in "$CERT_DIR/$VM_NAME.pem" -noout >/dev/null 2>&1; then
           cp "$CERT_DIR/$VM_NAME.pem" "$CERT_FILE"
           chown root:spire "$CERT_FILE"
           chmod 0644 "$CERT_FILE"
           echo "DevID certificate received and stored at $CERT_FILE"
           exit 0
+        elif [ -f "$CERT_DIR/$VM_NAME.pem" ]; then
+          echo "WARNING: Signed cert for $VM_NAME is empty/invalid, waiting for refresh"
         fi
         if [ $((i % 10)) -eq 0 ]; then
           echo "Still waiting for cert... ($i/120)"

--- a/modules/common/security/spiffe/server.nix
+++ b/modules/common/security/spiffe/server.nix
@@ -1,0 +1,459 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPIRE Server Module
+#
+# Runs the SPIRE server (identity authority) on admin-vm.
+# Supports dual attestation: join_token for app VMs + tpm_devid for system VMs.
+# Server address is derived from hostConfig (not hardcoded).
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.server;
+
+  tpmAttestationEnabled = cfg.tpmAttestation.enable;
+
+  # Generate server.conf HCL
+  serverConf = ''
+    server {
+      bind_address = "${cfg.bindAddress}"
+      bind_port = ${toString cfg.bindPort}
+      trust_domain = "${cfg.trustDomain}"
+      data_dir = "${cfg.dataDir}"
+      log_level = "${cfg.logLevel}"
+      socket_path = "${cfg.socketPath}"
+    }
+    plugins {
+      DataStore "sql" {
+        plugin_data {
+          database_type = "sqlite3"
+          connection_string = "${cfg.dataDir}/datastore.sqlite3"
+        }
+      }
+      KeyManager "disk" {
+        plugin_data {
+          keys_path = "${cfg.dataDir}/keys.json"
+        }
+      }
+      NodeAttestor "join_token" {
+        plugin_data {}
+      }
+  ''
+  + lib.optionalString tpmAttestationEnabled ''
+    NodeAttestor "tpm_devid" {
+      plugin_data {
+        devid_ca_path = "${cfg.tpmAttestation.devidCaPath}"
+        endorsement_ca_path = "${cfg.tpmAttestation.endorsementCaPath}"
+      }
+    }
+  ''
+  + ''
+    }
+  '';
+
+  spireGenerateJoinTokensApp = pkgs.writeShellApplication {
+    name = "spire-generate-join-tokens";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gawk
+      pkgs.spire
+    ];
+    text = ''
+      mkdir -p "${cfg.tokenDir}"
+      chmod 755 "${cfg.tokenDir}"
+
+      # Wait until the server is up
+      for i in $(seq 1 60); do
+        if spire-server healthcheck -socketPath ${cfg.socketPath} >/dev/null 2>&1; then
+          echo "SPIRE server is ready"
+          break
+        fi
+        echo "Waiting for SPIRE server... ($i/60)"
+        sleep 1
+      done
+
+      for vm in ${lib.concatStringsSep " " cfg.spireAgentVMs}; do
+        f="${cfg.tokenDir}/''${vm}.token"
+
+        # Check if agent is already registered
+        if spire-server agent list -socketPath ${cfg.socketPath} 2>/dev/null | grep -q "spiffe://${cfg.trustDomain}/agent/''${vm}"; then
+          echo "Agent $vm already registered, skipping token generation"
+          continue
+        fi
+
+        echo "Generating new token for $vm"
+        token="$(spire-server token generate \
+          -socketPath ${cfg.socketPath} \
+          | awk '/^Token:/ {print $2}')"
+
+        printf '%s\n' "$token" > "$f"
+        chmod 0644 "$f"
+        echo "Token written to $f"
+      done
+    '';
+  };
+
+  spirePublishBundleApp = pkgs.writeShellApplication {
+    name = "spire-publish-bundle";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.spire
+    ];
+    text = ''
+      out="${cfg.bundleOutPath}"
+      mkdir -p "$(dirname "$out")"
+
+      # Wait until the server API socket exists and the server is ready
+      for _ in $(seq 1 60); do
+        if [ -S "${cfg.socketPath}" ] && spire-server healthcheck -socketPath "${cfg.socketPath}" >/dev/null 2>&1; then
+          break
+        fi
+        sleep 1
+      done
+
+      if [ ! -S "${cfg.socketPath}" ]; then
+        echo "ERROR: SPIRE server socket not found at ${cfg.socketPath}" >&2
+        exit 1
+      fi
+
+      tmp="$(mktemp)"
+      spire-server bundle show -socketPath "${cfg.socketPath}" > "$tmp"
+      if [ ! -s "$tmp" ]; then
+        echo "ERROR: bundle export produced empty output" >&2
+        exit 1
+      fi
+
+      install -m 0644 -o root -g root "$tmp" "$out"
+      rm -f "$tmp"
+      echo "Wrote $out"
+    '';
+  };
+
+  spireCreateWorkloadEntriesApp = pkgs.writeShellApplication {
+    name = "spire-create-workload-entries";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gawk
+      pkgs.gnugrep
+      pkgs.spire
+    ];
+    text = ''
+      SOCKET="${cfg.socketPath}"
+      TRUST_DOMAIN="${cfg.trustDomain}"
+      EXPECTED_AGENTS=${toString (builtins.length cfg.spireAgentVMs)}
+
+      echo "=== SPIRE Workload Entry Creator ==="
+      echo "Expected agents: $EXPECTED_AGENTS"
+
+      # Wait for server
+      for _ in $(seq 1 60); do
+        if spire-server healthcheck -socketPath "$SOCKET" >/dev/null 2>&1; then
+          echo "Server ready"
+          break
+        fi
+        sleep 1
+      done
+
+      # Wait for ALL expected agents (up to 3 minutes)
+      echo "Waiting for all $EXPECTED_AGENTS agents to register..."
+      AGENT_COUNT=0
+      for i in $(seq 1 90); do
+        AGENT_COUNT=$(spire-server agent list -socketPath "$SOCKET" 2>/dev/null | grep "SPIFFE ID" | wc -l)
+        if [ "$AGENT_COUNT" -ge "$EXPECTED_AGENTS" ]; then
+          echo "All agents registered: $AGENT_COUNT/$EXPECTED_AGENTS"
+          break
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Waiting... $AGENT_COUNT/$EXPECTED_AGENTS agents [$i/90]"
+        fi
+        sleep 2
+      done
+
+      if [ "$AGENT_COUNT" -lt "$EXPECTED_AGENTS" ]; then
+        echo "WARNING: Only $AGENT_COUNT/$EXPECTED_AGENTS agents registered after timeout"
+        echo "Continuing with available agents..."
+      fi
+
+      # Get ALL agent IDs
+      AGENT_IDS=$(spire-server agent list -socketPath "$SOCKET" 2>/dev/null \
+        | grep "SPIFFE ID" \
+        | awk -F': ' '{print $2}' \
+        | tr -d ' ')
+
+      if [ -z "$AGENT_IDS" ]; then
+        echo "ERROR: No agents found"
+        exit 1
+      fi
+
+      AGENT_COUNT=$(echo "$AGENT_IDS" | wc -l)
+      echo ""
+      echo "Creating entries for $AGENT_COUNT agents..."
+
+      # Workload names
+      WORKLOADS=( ${lib.concatMapStringsSep " " (e: lib.escapeShellArg e.name) cfg.workloadEntries} )
+
+      # Create entries for EACH agent
+      CREATED=0
+      SKIPPED=0
+
+      for PARENT_ID in $AGENT_IDS; do
+        echo ""
+        echo "--- Agent: $PARENT_ID ---"
+
+        for WORKLOAD in "''${WORKLOADS[@]}"; do
+          SPIFFE_ID="spiffe://$TRUST_DOMAIN/workload/$WORKLOAD"
+
+          # Check if entry exists for this agent+workload combo
+          EXISTS=$(spire-server entry show -socketPath "$SOCKET" 2>/dev/null | grep -A1 "$SPIFFE_ID" | grep "$PARENT_ID" | wc -l)
+
+          if [ "$EXISTS" -gt 0 ]; then
+            echo "  [skip] $WORKLOAD"
+            SKIPPED=$((SKIPPED + 1))
+          else
+            echo "  [create] $WORKLOAD"
+            spire-server entry create \
+              -socketPath "$SOCKET" \
+              -parentID "$PARENT_ID" \
+              -spiffeID "$SPIFFE_ID" \
+              -selector unix:user:ghaf >/dev/null 2>&1 || echo "  [FAILED] $WORKLOAD"
+            CREATED=$((CREATED + 1))
+          fi
+        done
+      done
+
+      echo "Done: created=$CREATED skipped=$SKIPPED"
+    '';
+  };
+in
+{
+  _file = ./server.nix;
+
+  options.ghaf.security.spiffe.server = {
+    enable = lib.mkEnableOption "SPIRE server";
+
+    trustDomain = lib.mkOption {
+      type = lib.types.str;
+      default = "ghaf.internal";
+      description = "SPIFFE trust domain served by SPIRE server";
+    };
+
+    bindAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "SPIRE server bind address";
+    };
+
+    bindPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8081;
+      description = "SPIRE server bind port";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spire/server";
+      description = "SPIRE server state directory";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "INFO";
+      description = "SPIRE server log level";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Open firewall for SPIRE server bind port";
+    };
+
+    spireAgentVMs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "List of VM names that will run spire-agent";
+    };
+
+    tokenDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/tokens";
+      description = "Directory where join tokens are stored (virtiofs)";
+    };
+
+    bundleOutPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/common/spire/bundle.pem";
+      description = "Path where the SPIRE trust bundle is published (virtiofs)";
+    };
+
+    generateJoinTokens = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Generate join tokens for listed VMs";
+    };
+
+    publishBundle = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Publish the SPIRE trust bundle to bundleOutPath";
+    };
+
+    socketPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/tmp/spire-server/private/api.sock";
+      description = "Unix socket for spire-server";
+    };
+
+    createWorkloadEntries = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Auto-create workload entries";
+    };
+
+    workloadEntries = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            name = lib.mkOption {
+              type = lib.types.str;
+              description = "Workload name";
+            };
+            selectors = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ "unix:user:ghaf" ];
+              description = "Workload selectors";
+            };
+          };
+        }
+      );
+      default = [ ];
+      description = "Workload entries to register";
+    };
+
+    tpmAttestation = {
+      enable = lib.mkEnableOption "TPM DevID attestation on SPIRE server";
+
+      devidCaPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/ca/ca.pem";
+        description = "Path to the DevID CA certificate";
+      };
+
+      endorsementCaPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/spire/ca/endorsement-ca.pem";
+        description = ''
+          Path to TPM manufacturer endorsement key CA certificate(s).
+          Used to verify TPM genuineness during DevID attestation.
+          For production, bundle real manufacturer root CAs (e.g. Infineon).
+          The DevID CA setup creates a placeholder here on first boot.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.spire ];
+
+    users.groups.spire = { };
+    users.users.spire = {
+      isSystemUser = true;
+      group = "spire";
+    };
+
+    environment.etc."spire/server.conf".text = serverConf;
+
+    systemd.tmpfiles.rules = [
+      "d /tmp/spire-server 0755 root root - -"
+      "d /tmp/spire-server/private 0755 spire spire - -"
+    ]
+    ++ lib.optionals cfg.generateJoinTokens [
+      "d ${cfg.tokenDir} 0755 root root - -"
+    ];
+
+    systemd.services.spire-server = {
+      description = "SPIRE Server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = "spire";
+        Group = "spire";
+
+        ExecStart = "${pkgs.spire}/bin/spire-server run -config /etc/spire/server.conf";
+
+        StateDirectory = "spire/server";
+        StateDirectoryMode = "0750";
+
+        Restart = "on-failure";
+        RestartSec = "2s";
+
+        NoNewPrivileges = true;
+        PrivateTmp = false;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [
+          cfg.dataDir
+          "/tmp/spire-server"
+        ];
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.bindPort ];
+
+    systemd.services.spire-generate-join-tokens = lib.mkIf cfg.generateJoinTokens {
+      description = "Generate SPIRE join tokens for Ghaf VMs";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "spire-server.service"
+        "network-online.target"
+      ];
+      wants = [
+        "spire-server.service"
+        "network-online.target"
+      ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "root";
+        ExecStart = lib.getExe spireGenerateJoinTokensApp;
+      };
+    };
+
+    systemd.services.spire-publish-bundle = lib.mkIf cfg.publishBundle {
+      description = "Publish SPIRE trust bundle";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "spire-server.service" ];
+      wants = [ "spire-server.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        ExecStart = lib.getExe spirePublishBundleApp;
+      };
+    };
+
+    systemd.services.spire-create-workload-entries = lib.mkIf cfg.createWorkloadEntries {
+      description = "Create SPIRE workload entries";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "spire-server.service"
+        "spire-generate-join-tokens.service"
+      ];
+      wants = [ "spire-server.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "root";
+        ExecStart = lib.getExe spireCreateWorkloadEntriesApp;
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/server.nix
+++ b/modules/common/security/spiffe/server.nix
@@ -395,8 +395,17 @@ in
     systemd.services.spire-server = {
       description = "SPIRE Server";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+      ]
+      ++ lib.optionals config.ghaf.storagevm.encryption.enable [
+        "storagevm-enroll.service"
+      ];
       wants = [ "network-online.target" ];
+      unitConfig = {
+        # Ensure dataDir bind mount from encrypted storage is ready
+        RequiresMountsFor = [ cfg.dataDir ];
+      };
 
       serviceConfig = {
         User = "spire";

--- a/modules/common/security/spiffe/tpm-ek-verify.nix
+++ b/modules/common/security/spiffe/tpm-ek-verify.nix
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM EK Certificate Verification Module
+#
+# Runs at boot on system VMs with hardware TPM to read the Endorsement Key
+# certificate from TPM NV RAM and verify its chain against the combined
+# endorsement CA bundle (all.pem).
+#
+# This is informational/defense-in-depth — the SPIRE server also validates
+# the endorsement chain during tpm_devid attestation. This service writes
+# status files to /run/tpm/ for operators/monitoring.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.tpmEkVerify;
+
+  tpmEkVerifyApp = pkgs.writeShellApplication {
+    name = "tpm-ek-verify";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.tpm2-tools
+      pkgs.openssl
+    ];
+    text = ''
+      EK_NV_RSA="0x01C00002"
+      EK_NV_ECC="0x01C0000A"
+      BUNDLE_PATH="${cfg.endorsementCaBundle}"
+
+      mkdir -p /run/tpm
+
+      # Try to read RSA EK cert first, fall back to ECC
+      EK_TYPE=""
+      if tpm2_nvread "$EK_NV_RSA" -o /run/tpm/ek-cert.der 2>/dev/null; then
+        EK_TYPE="RSA"
+      elif tpm2_nvread "$EK_NV_ECC" -o /run/tpm/ek-cert.der 2>/dev/null; then
+        EK_TYPE="ECC"
+      else
+        echo "WARNING: No EK cert found in TPM NV RAM"
+        echo "no-ek-cert" > /run/tpm/ek-status
+        exit 0
+      fi
+
+      echo "$EK_TYPE" > /run/tpm/ek-type
+
+      # Convert DER to PEM
+      if ! openssl x509 -inform DER -in /run/tpm/ek-cert.der -out /run/tpm/ek-cert.pem 2>/dev/null; then
+        echo "WARNING: Could not convert EK cert from DER to PEM"
+        echo "conversion-failed" > /run/tpm/ek-status
+        exit 0
+      fi
+
+      # Validate chain against all known endorsement CAs
+      if openssl verify -partial_chain -CAfile "$BUNDLE_PATH" /run/tpm/ek-cert.pem >/dev/null 2>&1; then
+        echo "verified" > /run/tpm/ek-status
+        ISSUER=$(openssl x509 -in /run/tpm/ek-cert.pem -noout -issuer 2>/dev/null)
+        echo "EK cert ($EK_TYPE) verified: $ISSUER"
+      else
+        echo "chain-invalid" > /run/tpm/ek-status
+        echo "WARNING: EK cert chain validation failed — TPM may not be genuine"
+        echo "This is advisory only — SPIRE server will also validate"
+      fi
+    '';
+  };
+in
+{
+  _file = ./tpm-ek-verify.nix;
+
+  options.ghaf.security.spiffe.tpmEkVerify = {
+    enable = lib.mkEnableOption "TPM EK certificate verification at boot";
+
+    endorsementCaBundle = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Path to combined endorsement CA bundle (all.pem)";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.tpm-ek-verify = {
+      description = "Verify TPM EK certificate chain at boot";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "local-fs.target"
+        "tpm-vendor-detect.service"
+      ];
+      before = [ "spire-devid-provision.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe tpmEkVerifyApp;
+      };
+    };
+  };
+}

--- a/modules/common/security/spiffe/tpm-vendor-detect.nix
+++ b/modules/common/security/spiffe/tpm-vendor-detect.nix
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM Vendor Detection Module
+#
+# Runs at boot on system VMs with hardware TPM to detect the actual
+# TPM manufacturer. Writes vendor info to /run/tpm/ for downstream
+# services (tpm-ek-verify, monitoring).
+#
+# If expectedVendors is set and the detected vendor doesn't match,
+# a warning is logged (but the service still succeeds — advisory only).
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.ghaf.security.spiffe.tpmVendorDetect;
+
+  tpmVendorDetectApp = pkgs.writeShellApplication {
+    name = "tpm-vendor-detect";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gawk
+      pkgs.gnused
+      pkgs.tpm2-tools
+    ];
+    text = ''
+      mkdir -p /run/tpm
+
+      # Read TPM manufacturer code
+      VENDOR_HEX=$(tpm2_getcap properties-fixed 2>/dev/null \
+        | grep TPM2_PT_MANUFACTURER -A1 | grep 'raw:' | awk '{print $2}') || true
+
+      if [ -z "$VENDOR_HEX" ]; then
+        echo "WARNING: Could not read TPM manufacturer property"
+        echo "unknown" > /run/tpm/vendor
+        echo "" > /run/tpm/vendor-code
+        exit 0
+      fi
+
+      # Convert hex to ASCII string (e.g., 0x49465800 -> "IFX")
+      # Strip 0x prefix, convert byte pairs to decimal, then to chars via awk
+      VENDOR_CODE=$(echo "$VENDOR_HEX" | sed 's/^0x//' | fold -w2 \
+        | awk '{val=strtonum("0x"$1); if(val>0) printf "%c",val}')
+
+      # Map vendor codes to TrustedTpm.cab names
+      case "$VENDOR_CODE" in
+        INTC) VENDOR_NAME="Intel" ;;
+        IFX*)  VENDOR_NAME="Infineon" ;;
+        AMD*)  VENDOR_NAME="AMD" ;;
+        STM*)  VENDOR_NAME="STMicro" ;;
+        NTC*)  VENDOR_NAME="Nuvoton" ;;
+        QCOM) VENDOR_NAME="QC" ;;
+        MSFT) VENDOR_NAME="Microsoft" ;;
+        ATML) VENDOR_NAME="Atmel" ;;
+        NTZ*)  VENDOR_NAME="NationZ" ;;
+        *)    VENDOR_NAME="Unknown" ;;
+      esac
+
+      echo "$VENDOR_NAME" > /run/tpm/vendor
+      echo "$VENDOR_CODE" > /run/tpm/vendor-code
+      echo "TPM vendor: $VENDOR_NAME ($VENDOR_CODE)"
+
+      # Advisory check against expected vendors
+      EXPECTED_VENDORS="${lib.concatStringsSep " " cfg.expectedVendors}"
+      if [ -n "$EXPECTED_VENDORS" ]; then
+        MATCH=0
+        for v in $EXPECTED_VENDORS; do
+          if [ "$v" = "$VENDOR_NAME" ]; then
+            MATCH=1
+            break
+          fi
+        done
+        if [ "$MATCH" -eq 0 ]; then
+          echo "WARNING: Detected TPM vendor '$VENDOR_NAME' not in expected list: $EXPECTED_VENDORS"
+          echo "This is advisory only — attestation will still proceed"
+        fi
+      fi
+    '';
+  };
+in
+{
+  _file = ./tpm-vendor-detect.nix;
+
+  options.ghaf.security.spiffe.tpmVendorDetect = {
+    enable = lib.mkEnableOption "TPM vendor detection at boot";
+
+    expectedVendors = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Expected vendor names (advisory, for warning on mismatch).
+        Examples: "Intel", "Infineon", "AMD".
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.tpm-vendor-detect = {
+      description = "Detect TPM manufacturer at boot";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "local-fs.target" ];
+      before = [
+        "tpm-ek-verify.service"
+        "spire-devid-provision.service"
+      ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe tpmVendorDetectApp;
+      };
+    };
+  };
+}

--- a/modules/hardware/common/default.nix
+++ b/modules/hardware/common/default.nix
@@ -7,5 +7,6 @@
     ./input.nix
     ./kernel.nix
     ./qemu.nix
+    ./tpm-endorsement.nix
   ];
 }

--- a/modules/hardware/common/tpm-endorsement.nix
+++ b/modules/hardware/common/tpm-endorsement.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM Endorsement CA Wiring Module
+#
+# Resolves vendor names from hardware definition to cert paths from the
+# tpm-endorsement-certs package and propagates them to globalConfig.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  hwDef = config.ghaf.hardware.definition.tpm;
+  # Per-vendor certs (kept for backward compat)
+  vendorCerts = map (v: "${pkgs.tpm-endorsement-certs}/vendors/${v}.pem") hwDef.endorsementCaVendors;
+  allCerts = vendorCerts ++ hwDef.endorsementCaCerts;
+  # Combined bundle with ALL vendor CAs — used by SPIRE server
+  allCertsBundle = "${pkgs.tpm-endorsement-certs}/all.pem";
+in
+{
+  _file = ./tpm-endorsement.nix;
+
+  config = {
+    # Always set the combined bundle (accepts any genuine TPM)
+    ghaf.global-config.spiffe.tpmAttestation.endorsementCaBundle = lib.mkDefault allCertsBundle;
+
+    # Propagate vendor names as advisory (for runtime mismatch warnings)
+    ghaf.global-config.spiffe.tpmAttestation.endorsementCaVendors =
+      lib.mkDefault hwDef.endorsementCaVendors;
+
+    # Keep per-vendor certs for backward compat
+    ghaf.global-config.spiffe.tpmAttestation.endorsementCaCerts = lib.mkIf (allCerts != [ ]) (
+      lib.mkDefault allCerts
+    );
+  };
+}

--- a/modules/hardware/definition.nix
+++ b/modules/hardware/definition.nix
@@ -415,6 +415,31 @@ in
         };
       };
 
+      tpm = {
+        endorsementCaVendors = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          description = ''
+            TPM manufacturer vendor names (matching TrustedTpm.cab folder names).
+            Examples: "Intel", "Infineon", "AMD", "STMicro", "Nuvoton".
+            Multiple vendors supported for targets that ship with different TPMs
+            depending on SKU or production batch.
+          '';
+          example = [
+            "Intel"
+            "Infineon"
+          ];
+        };
+        endorsementCaCerts = mkOption {
+          type = types.listOf types.path;
+          default = [ ];
+          description = ''
+            Additional custom endorsement CA cert paths (PEM files).
+            Use for TPM vendors not in the TrustedTpm.cab bundle.
+          '';
+        };
+      };
+
       netvm = {
         extraModules = mkOption {
           description = ''

--- a/modules/hardware/x86_64-generic/modules/tpm2.nix
+++ b/modules/hardware/x86_64-generic/modules/tpm2.nix
@@ -30,8 +30,8 @@ in
 
     assertions = [
       {
-        assertion = pkgs.stdenv.isx86_64;
-        message = "TPM2 is only supported on x86_64";
+        assertion = pkgs.stdenv.isx86_64 || pkgs.stdenv.isAarch64;
+        message = "TPM2 is only supported on x86_64 and aarch64";
       }
     ];
   };

--- a/modules/hardware/x86_64-generic/modules/tpm2.nix
+++ b/modules/hardware/x86_64-generic/modules/tpm2.nix
@@ -8,6 +8,110 @@
 }:
 let
   cfg = config.ghaf.hardware.tpm2;
+
+  tpmHierarchyUnlockScript = pkgs.writeShellApplication {
+    name = "tpm-hierarchy-unlock";
+    runtimeInputs = [
+      pkgs.tpm2-tools
+      pkgs.coreutils
+    ];
+    text = ''
+      FLAG="/var/lib/tpm-cleared"
+
+      # Try both TCTI devices — resource manager first, then direct
+      for tcti in "device:/dev/tpmrm0" "device:/dev/tpm0"; do
+        dev="''${tcti##*:}"
+        echo "Trying $dev ..."
+        export TPM2TOOLS_TCTI="$tcti"
+
+        # Test if owner hierarchy is usable on this device
+        if tpm2_createprimary -C owner -c /tmp/tpm-test.ctx -Q 2>/dev/null; then
+          rm -f /tmp/tpm-test.ctx
+          echo "TPM owner hierarchy is accessible via $dev"
+          exit 0
+        fi
+
+        echo "Owner hierarchy locked on $dev — attempting recovery via platform hierarchy"
+
+        # Try re-enabling owner and endorsement hierarchies via PH
+        if tpm2_hierarchycontrol -C platform ownerEnable set 2>/dev/null; then
+          echo "Owner hierarchy re-enabled via $dev"
+          tpm2_hierarchycontrol -C platform endorseEnable set 2>/dev/null \
+            && echo "Endorsement hierarchy re-enabled via $dev" \
+            || echo "WARNING: Could not re-enable endorsement hierarchy via $dev"
+
+          # Verify createprimary works after re-enable
+          if tpm2_createprimary -C owner -c /tmp/tpm-test.ctx -Q 2>/dev/null; then
+            rm -f /tmp/tpm-test.ctx
+            echo "Owner hierarchy confirmed working after re-enable"
+            exit 0
+          fi
+          rm -f /tmp/tpm-test.ctx
+          echo "Owner hierarchy still not usable after re-enable"
+        fi
+
+        # Last resort: factory-reset TPM via platform hierarchy.
+        # This clears unknown auth values left by a previous OS installation.
+        # Only attempt once — the flag file prevents repeated clears.
+        if [ ! -f "$FLAG" ]; then
+          echo "Attempting TPM factory reset via platform hierarchy on $dev ..."
+          if tpm2_clear -c platform 2>/dev/null; then
+            echo "TPM factory reset successful — all auth values cleared"
+            mkdir -p "$(dirname "$FLAG")"
+            date -Iseconds > "$FLAG"
+            # After clear, hierarchies are re-enabled with empty auth
+            exit 0
+          else
+            echo "TPM factory reset failed on $dev"
+          fi
+        fi
+
+        echo "Platform hierarchy also locked on $dev"
+      done
+
+      echo "WARNING: Could not re-enable owner hierarchy on any device"
+      echo "VMs will fall back to non-TPM methods where possible"
+    '';
+  };
+
+  tpmHierarchyMonitorScript = pkgs.writeShellApplication {
+    name = "tpm-hierarchy-monitor";
+    runtimeInputs = [
+      pkgs.tpm2-tools
+      pkgs.coreutils
+      pkgs.psmisc # fuser
+    ];
+    text = ''
+      LOG="/tmp/tpm-hierarchy-monitor.log"
+      echo "=== TPM hierarchy monitor starting at $(date -Iseconds) ===" > "$LOG"
+      for i in $(seq 1 60); do
+        {
+          echo "--- t=$i $(date -Iseconds) ---"
+
+          echo "=== /dev/tpm0 (direct) ==="
+          TPM2TOOLS_TCTI="device:/dev/tpm0" tpm2_getcap properties-variable 2>&1 \
+            | grep -iE "(enable|lockout)" || echo "(tpm0 getcap failed)"
+
+          echo "=== /dev/tpmrm0 (resource manager) ==="
+          TPM2TOOLS_TCTI="device:/dev/tpmrm0" tpm2_getcap properties-variable 2>&1 \
+            | grep -iE "(enable|lockout)" || echo "(tpmrm0 getcap failed)"
+
+          echo "=== createprimary test ==="
+          TPM2TOOLS_TCTI="device:/dev/tpm0" tpm2_createprimary -C owner -c /tmp/tpm-test-tpm0.ctx -Q 2>&1 \
+            && echo "tpm0:owner=OK" || echo "tpm0:owner=FAIL"
+          rm -f /tmp/tpm-test-tpm0.ctx
+          TPM2TOOLS_TCTI="device:/dev/tpmrm0" tpm2_createprimary -C owner -c /tmp/tpm-test-tpmrm0.ctx -Q 2>&1 \
+            && echo "tpmrm0:owner=OK" || echo "tpmrm0:owner=FAIL"
+          rm -f /tmp/tpm-test-tpmrm0.ctx
+
+          echo "=== TPM device users ==="
+          fuser /dev/tpm0 /dev/tpmrm0 2>&1 || true
+        } >> "$LOG"
+        sleep 1
+      done
+      echo "=== Monitor complete ===" >> "$LOG"
+    '';
+  };
 in
 {
   _file = ./tpm2.nix;
@@ -19,7 +123,8 @@ in
   config = lib.mkIf cfg.enable {
     security.tpm2 = {
       enable = true;
-      pkcs11.enable = true;
+      # tpm2-pkcs11 cross-compilation is broken on aarch64 (tpm2-pytss patch conflict)
+      pkcs11.enable = pkgs.stdenv.isx86_64;
       abrmd.enable = false;
     };
 
@@ -34,5 +139,56 @@ in
         message = "TPM2 is only supported on x86_64 and aarch64";
       }
     ];
+
+    systemd.services = {
+      # After LUKS unlock the owner hierarchy may be disabled/locked.
+      # Re-enable it before VMs start so their TPM operations succeed.
+      tpm-hierarchy-unlock = {
+        description = "Re-enable TPM owner hierarchy after LUKS unlock";
+        after = [
+          "systemd-cryptsetup.target"
+          "systemd-tpm2-setup.service"
+        ];
+        before = [ "microvms.target" ];
+        wantedBy = [ "microvms.target" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = lib.getExe tpmHierarchyUnlockScript;
+        };
+      };
+
+      # Diagnostic: log hierarchy state every second for 60s starting before unlock.
+      # Check /tmp/tpm-hierarchy-monitor.log to compare /dev/tpm0 vs /dev/tpmrm0.
+      tpm-hierarchy-monitor = lib.mkIf config.ghaf.profiles.debug.enable {
+        description = "Monitor TPM hierarchy state during boot";
+        after = [
+          "systemd-cryptsetup.target"
+          "dev-tpm0.device"
+        ];
+        before = [ "tpm-hierarchy-unlock.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = lib.getExe tpmHierarchyMonitorScript;
+        };
+      };
+
+      # Re-enable owner hierarchy after VMs have started, in case VM initrd
+      # LUKS operations locked it again.
+      tpm-hierarchy-unlock-late = {
+        description = "Re-enable TPM owner hierarchy after VM boot";
+        after = [ "microvms.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          # Wait for VM initrd LUKS operations to complete
+          ExecStartPre = "${pkgs.coreutils}/bin/sleep 10";
+          ExecStart = lib.getExe tpmHierarchyUnlockScript;
+        };
+      };
+    };
   };
 }

--- a/modules/hardware/x86_64-generic/modules/tpm2.nix
+++ b/modules/hardware/x86_64-generic/modules/tpm2.nix
@@ -18,100 +18,61 @@ let
     text = ''
       FLAG="/var/lib/tpm-cleared"
 
-      # Try both TCTI devices — resource manager first, then direct
-      for tcti in "device:/dev/tpmrm0" "device:/dev/tpm0"; do
-        dev="''${tcti##*:}"
-        echo "Trying $dev ..."
-        export TPM2TOOLS_TCTI="$tcti"
+      # Use TPM resource manager device only.
+      tcti="device:/dev/tpmrm0"
+      dev="''${tcti##*:}"
+      echo "Trying $dev ..."
+      export TPM2TOOLS_TCTI="$tcti"
 
-        # Test if owner hierarchy is usable on this device
+      # Test if owner hierarchy is usable on this device
+      if tpm2_createprimary -C owner -c /tmp/tpm-test.ctx -Q 2>/dev/null; then
+        rm -f /tmp/tpm-test.ctx
+        echo "TPM owner hierarchy is accessible via $dev"
+        exit 0
+      fi
+
+      echo "Owner hierarchy locked on $dev — attempting recovery via platform hierarchy"
+
+      # Try re-enabling owner and endorsement hierarchies via PH
+      if tpm2_hierarchycontrol -C platform ownerEnable set 2>/dev/null; then
+        echo "Owner hierarchy re-enabled via $dev"
+        tpm2_hierarchycontrol -C platform endorseEnable set 2>/dev/null \
+          && echo "Endorsement hierarchy re-enabled via $dev" \
+          || echo "WARNING: Could not re-enable endorsement hierarchy via $dev"
+
+        # Verify createprimary works after re-enable
         if tpm2_createprimary -C owner -c /tmp/tpm-test.ctx -Q 2>/dev/null; then
           rm -f /tmp/tpm-test.ctx
-          echo "TPM owner hierarchy is accessible via $dev"
+          echo "Owner hierarchy confirmed working after re-enable"
           exit 0
         fi
+        rm -f /tmp/tpm-test.ctx
+        echo "Owner hierarchy still not usable after re-enable"
+      fi
 
-        echo "Owner hierarchy locked on $dev — attempting recovery via platform hierarchy"
-
-        # Try re-enabling owner and endorsement hierarchies via PH
-        if tpm2_hierarchycontrol -C platform ownerEnable set 2>/dev/null; then
-          echo "Owner hierarchy re-enabled via $dev"
-          tpm2_hierarchycontrol -C platform endorseEnable set 2>/dev/null \
-            && echo "Endorsement hierarchy re-enabled via $dev" \
-            || echo "WARNING: Could not re-enable endorsement hierarchy via $dev"
-
-          # Verify createprimary works after re-enable
-          if tpm2_createprimary -C owner -c /tmp/tpm-test.ctx -Q 2>/dev/null; then
-            rm -f /tmp/tpm-test.ctx
-            echo "Owner hierarchy confirmed working after re-enable"
-            exit 0
-          fi
-          rm -f /tmp/tpm-test.ctx
-          echo "Owner hierarchy still not usable after re-enable"
+      # Last resort: factory-reset TPM via platform hierarchy.
+      # This clears unknown auth values left by a previous OS installation.
+      # Only attempt once — the flag file prevents repeated clears.
+      if [ ! -f "$FLAG" ]; then
+        echo "Attempting TPM factory reset via platform hierarchy on $dev ..."
+        if tpm2_clear -c platform 2>/dev/null; then
+          echo "TPM factory reset successful — all auth values cleared"
+          mkdir -p "$(dirname "$FLAG")"
+          date -Iseconds > "$FLAG"
+          # After clear, hierarchies are re-enabled with empty auth
+          exit 0
+        else
+          echo "TPM factory reset failed on $dev"
         fi
+      fi
 
-        # Last resort: factory-reset TPM via platform hierarchy.
-        # This clears unknown auth values left by a previous OS installation.
-        # Only attempt once — the flag file prevents repeated clears.
-        if [ ! -f "$FLAG" ]; then
-          echo "Attempting TPM factory reset via platform hierarchy on $dev ..."
-          if tpm2_clear -c platform 2>/dev/null; then
-            echo "TPM factory reset successful — all auth values cleared"
-            mkdir -p "$(dirname "$FLAG")"
-            date -Iseconds > "$FLAG"
-            # After clear, hierarchies are re-enabled with empty auth
-            exit 0
-          else
-            echo "TPM factory reset failed on $dev"
-          fi
-        fi
-
-        echo "Platform hierarchy also locked on $dev"
-      done
+      echo "Platform hierarchy also locked on $dev"
 
       echo "WARNING: Could not re-enable owner hierarchy on any device"
       echo "VMs will fall back to non-TPM methods where possible"
     '';
   };
 
-  tpmHierarchyMonitorScript = pkgs.writeShellApplication {
-    name = "tpm-hierarchy-monitor";
-    runtimeInputs = [
-      pkgs.tpm2-tools
-      pkgs.coreutils
-      pkgs.psmisc # fuser
-    ];
-    text = ''
-      LOG="/tmp/tpm-hierarchy-monitor.log"
-      echo "=== TPM hierarchy monitor starting at $(date -Iseconds) ===" > "$LOG"
-      for i in $(seq 1 60); do
-        {
-          echo "--- t=$i $(date -Iseconds) ---"
-
-          echo "=== /dev/tpm0 (direct) ==="
-          TPM2TOOLS_TCTI="device:/dev/tpm0" tpm2_getcap properties-variable 2>&1 \
-            | grep -iE "(enable|lockout)" || echo "(tpm0 getcap failed)"
-
-          echo "=== /dev/tpmrm0 (resource manager) ==="
-          TPM2TOOLS_TCTI="device:/dev/tpmrm0" tpm2_getcap properties-variable 2>&1 \
-            | grep -iE "(enable|lockout)" || echo "(tpmrm0 getcap failed)"
-
-          echo "=== createprimary test ==="
-          TPM2TOOLS_TCTI="device:/dev/tpm0" tpm2_createprimary -C owner -c /tmp/tpm-test-tpm0.ctx -Q 2>&1 \
-            && echo "tpm0:owner=OK" || echo "tpm0:owner=FAIL"
-          rm -f /tmp/tpm-test-tpm0.ctx
-          TPM2TOOLS_TCTI="device:/dev/tpmrm0" tpm2_createprimary -C owner -c /tmp/tpm-test-tpmrm0.ctx -Q 2>&1 \
-            && echo "tpmrm0:owner=OK" || echo "tpmrm0:owner=FAIL"
-          rm -f /tmp/tpm-test-tpmrm0.ctx
-
-          echo "=== TPM device users ==="
-          fuser /dev/tpm0 /dev/tpmrm0 2>&1 || true
-        } >> "$LOG"
-        sleep 1
-      done
-      echo "=== Monitor complete ===" >> "$LOG"
-    '';
-  };
 in
 {
   _file = ./tpm2.nix;
@@ -156,22 +117,6 @@ in
           Type = "oneshot";
           RemainAfterExit = true;
           ExecStart = lib.getExe tpmHierarchyUnlockScript;
-        };
-      };
-
-      # Diagnostic: log hierarchy state every second for 60s starting before unlock.
-      # Check /tmp/tpm-hierarchy-monitor.log to compare /dev/tpm0 vs /dev/tpmrm0.
-      tpm-hierarchy-monitor = lib.mkIf config.ghaf.profiles.debug.enable {
-        description = "Monitor TPM hierarchy state during boot";
-        after = [
-          "systemd-cryptsetup.target"
-          "dev-tpm0.device"
-        ];
-        before = [ "tpm-hierarchy-unlock.service" ];
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          Type = "simple";
-          ExecStart = lib.getExe tpmHierarchyMonitorScript;
         };
       };
 

--- a/modules/microvm/common/storagevm.nix
+++ b/modules/microvm/common/storagevm.nix
@@ -163,7 +163,7 @@ in
                 echo -n > temp_keyfile
                 chmod 600 temp_keyfile
                 systemd-cryptenroll --unlock-key-file=temp_keyfile \
-                  --tpm2-device=/dev/tpm0 --tpm2-pcrs="${cfg.encryption.pcrs}" \
+                  --tpm2-device=/dev/tpmrm0 --tpm2-pcrs="${cfg.encryption.pcrs}" \
                   ${lib.optionalString tpm.passthrough.enable "--tpm2-seal-key-handle=${tpm.passthrough.rootNVIndex}"} "${drivePath}"
                 rm temp_keyfile
                 ${lib.optionalString (!cfg.encryption.keepDefaultPassword) ''

--- a/modules/microvm/common/vm-tpm.nix
+++ b/modules/microvm/common/vm-tpm.nix
@@ -67,6 +67,10 @@ in
         }
       ];
 
+      services.udev.extraRules = ''
+        KERNEL=="tpm0", MODE="0660", GROUP="${config.security.tpm2.tssGroup or "tss"}"
+      '';
+
       microvm.qemu = {
         extraArgs =
           let

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -129,6 +129,21 @@ in
         };
         logging.client.enable = config.ghaf.logging.enable;
         common.extraNetworking.hosts.ghaf-host = cfg.extraNetworking;
+
+        # SPIFFE/SPIRE agent on host
+        security.spiffe = lib.mkIf (config.ghaf.global-config.spiffe.enable or false) {
+          enable = true;
+          agent = {
+            enable = true;
+            serverAddress =
+              config.ghaf.networking.hosts.${config.ghaf.global-config.spiffe.serverVm or "admin-vm"}.ipv4
+                or "127.0.0.1";
+            serverPort = config.ghaf.global-config.spiffe.serverPort or 8081;
+            trustDomain = config.ghaf.global-config.spiffe.trustDomain or "ghaf.internal";
+            joinTokenFile = "/persist/common/spire/tokens/${config.networking.hostName}.token";
+            trustBundlePath = "/persist/common/spire/bundle.pem";
+          };
+        };
       };
 
       # Create required host directories

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -142,6 +142,8 @@ in
             trustDomain = config.ghaf.global-config.spiffe.trustDomain or "ghaf.internal";
             joinTokenFile = "/persist/common/spire/tokens/${config.networking.hostName}.token";
             trustBundlePath = "/persist/common/spire/bundle.pem";
+            # Host reads common dir at /persist/common (not /etc/common like VMs)
+            commonMountPath = "/persist/common";
           };
         };
       };

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -90,9 +90,14 @@ in
         "/etc/locale-givc.conf"
         "/etc/timezone.conf"
       ];
-      directories = lib.mkIf (globalConfig.storage.encryption.enable or false) [
-        "/var/lib/swtpm"
-      ];
+      directories = lib.mkIf (globalConfig.storage.encryption.enable or false) (
+        [
+          "/var/lib/swtpm"
+        ]
+        ++ lib.optionals (globalConfig.spiffe.enable or false) [
+          "/var/lib/spire"
+        ]
+      );
       encryption.enable = globalConfig.storage.encryption.enable or false;
     };
 
@@ -157,6 +162,50 @@ in
     security = {
       fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
+      # SPIFFE/SPIRE — admin-vm is the SPIRE server
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+
+        server = {
+          enable = true;
+          bindPort = globalConfig.spiffe.serverPort or 8081;
+          # Collect VM names for join token generation:
+          # all system VMs + app VMs + ghaf-host
+          spireAgentVMs =
+            let
+              sysvmNames = lib.mapAttrsToList (_: vm: vm.vmName) (hostConfig.sysvms or { });
+              appvmNames = lib.mapAttrsToList (name: _: "${name}-vm") (hostConfig.appvms or { });
+            in
+            sysvmNames ++ appvmNames ++ [ "ghaf-host" ];
+          generateJoinTokens = true;
+          publishBundle = true;
+          createWorkloadEntries = true;
+          workloadEntries = [
+            {
+              name = "workload";
+              selectors = [ "unix:user:ghaf" ];
+            }
+          ];
+          tpmAttestation = lib.mkIf (globalConfig.spiffe.tpmAttestation.enable or false) {
+            enable = true;
+            devidCaPath = "/var/lib/spire/ca/ca.pem";
+            endorsementCaPath = "/var/lib/spire/ca/endorsement-ca.pem";
+          };
+        };
+
+        # admin-vm also runs a SPIRE agent
+        agent = {
+          enable = true;
+          serverAddress = "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+        };
+
+        # DevID CA (signs certs for system VMs with TPM)
+        devidCa.enable = globalConfig.spiffe.tpmAttestation.enable or false;
+      };
     };
   };
 

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -111,18 +111,18 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough is only supported on x86_64
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81701000"; # TPM2 NV index for admin-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -190,8 +190,8 @@ in
           ];
           tpmAttestation = lib.mkIf (globalConfig.spiffe.tpmAttestation.enable or false) {
             enable = true;
-            devidCaPath = "/var/lib/spire/ca/ca.pem";
-            endorsementCaPath = "/var/lib/spire/ca/endorsement-ca.pem";
+            devidCaPath = "/etc/common/spire/ca/ca.pem";
+            endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
           };
         };
 

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -257,7 +257,22 @@ in
         };
 
         # Security
-        security.fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+        security = {
+          fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+
+          # SPIFFE/SPIRE agent (app VMs always use join_token)
+          spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+            enable = true;
+            trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+            agent = {
+              enable = true;
+              serverAddress =
+                hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+              serverPort = globalConfig.spiffe.serverPort or 8081;
+              joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+            };
+          };
+        };
       };
 
       # Combined udev rules (yubikey + passthrough)

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -100,18 +100,18 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough is only supported on x86_64
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81702000"; # TPM2 NV index for audio-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -166,7 +166,7 @@ in
           attestationMode =
             if
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             then
               "tpm_devid"
             else
@@ -176,11 +176,31 @@ in
           lib.mkIf
             (
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             )
             {
               enable = true;
               inherit vmName;
+            };
+        tpmVendorDetect =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              expectedVendors = globalConfig.spiffe.tpmAttestation.endorsementCaVendors or [ ];
+            };
+        tpmEkVerify =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
             };
       };
     };

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -150,7 +150,40 @@ in
       server.endpoint = globalConfig.logging.server.endpoint or "";
     };
 
-    security.fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+    security = {
+      fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+
+      # SPIFFE/SPIRE agent
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+        agent = {
+          enable = true;
+          serverAddress =
+            hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+          attestationMode =
+            if
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            then
+              "tpm_devid"
+            else
+              "join_token";
+        };
+        devidProvision =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            )
+            {
+              enable = true;
+              inherit vmName;
+            };
+      };
+    };
 
     # Networking hosts - from hostConfig (for vm-networking.nix to look up MAC/IP)
     networking.hosts = hostConfig.networking.hosts or { };

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -98,9 +98,6 @@ in
       };
     };
 
-    # Security - from globalConfig
-    security.audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
-
     development = {
       ssh.daemon.enable = lib.mkDefault (globalConfig.development.ssh.daemon.enable or false);
       debug.tools.enable = lib.mkDefault (globalConfig.development.debug.tools.enable or false);
@@ -251,7 +248,45 @@ in
     };
 
     xdgitems.enable = true;
-    security.fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+
+    security = {
+      fail2ban.enable = globalConfig.development.ssh.daemon.enable or false;
+      # Security - from globalConfig
+      audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
+      # SPIFFE/SPIRE agent
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+        agent = {
+          enable = true;
+          serverAddress =
+            hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+          # Use TPM DevID attestation if enabled and this VM has hardware TPM
+          attestationMode =
+            if
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            then
+              "tpm_devid"
+            else
+              "join_token";
+        };
+        # DevID provisioning for system VMs with TPM
+        devidProvision =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            )
+            {
+              enable = true;
+              inherit vmName;
+            };
+      };
+    };
   };
 
   services = {

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -158,18 +158,18 @@ in
       };
 
       tpm.passthrough = {
-        # TPM passthrough is only supported on x86_64
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81703000"; # TPM2 NV index for gui-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -264,11 +264,11 @@ in
             hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
           serverPort = globalConfig.spiffe.serverPort or 8081;
           joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
-          # Use TPM DevID attestation if enabled and this VM has hardware TPM
+          # Use TPM DevID attestation if enabled and platform supports hardware TPM
           attestationMode =
             if
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             then
               "tpm_devid"
             else
@@ -279,11 +279,33 @@ in
           lib.mkIf
             (
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             )
             {
               enable = true;
               inherit vmName;
+            };
+        # Runtime TPM vendor detection (advisory)
+        tpmVendorDetect =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              expectedVendors = globalConfig.spiffe.tpmAttestation.endorsementCaVendors or [ ];
+            };
+        # Runtime EK cert chain validation (defense-in-depth)
+        tpmEkVerify =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
             };
       };
     };

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -110,19 +110,18 @@ in
       };
 
       tpm.passthrough = {
-        # At the moment the TPM is only used for storage encryption, so the features are coupled.
-        # TPM passthrough is only supported on x86_64.
+        # TPM passthrough supported on x86_64 and aarch64
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") == "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") != "riscv64-linux");
         rootNVIndex = "0x81704000"; # TPM2 NV index for net-vm LUKS key
       };
 
       tpm.emulated = {
-        # Use emulated TPM for non-x86_64 systems when encryption is enabled
+        # Use emulated TPM for platforms without hardware TPM support
         enable =
           (globalConfig.storage.encryption.enable or false)
-          && ((globalConfig.platform.hostSystem or "") != "x86_64-linux");
+          && ((globalConfig.platform.hostSystem or "") == "riscv64-linux");
         name = vmName;
       };
     };
@@ -183,7 +182,7 @@ in
           attestationMode =
             if
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             then
               "tpm_devid"
             else
@@ -193,11 +192,31 @@ in
           lib.mkIf
             (
               (globalConfig.spiffe.tpmAttestation.enable or false)
-              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
             )
             {
               enable = true;
               inherit vmName;
+            };
+        tpmVendorDetect =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              expectedVendors = globalConfig.spiffe.tpmAttestation.endorsementCaVendors or [ ];
+            };
+        tpmEkVerify =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") != "riscv64-linux")
+            )
+            {
+              enable = true;
+              endorsementCaBundle = globalConfig.spiffe.tpmAttestation.endorsementCaBundle or "";
             };
       };
     };

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -169,6 +169,37 @@ in
 
       # Audit - from globalConfig
       audit.enable = lib.mkDefault (globalConfig.security.audit.enable or false);
+
+      # SPIFFE/SPIRE agent
+      spiffe = lib.mkIf (globalConfig.spiffe.enable or false) {
+        enable = true;
+        trustDomain = globalConfig.spiffe.trustDomain or "ghaf.internal";
+        agent = {
+          enable = true;
+          serverAddress =
+            hostConfig.networking.hosts.${globalConfig.spiffe.serverVm or "admin-vm"}.ipv4 or "127.0.0.1";
+          serverPort = globalConfig.spiffe.serverPort or 8081;
+          joinTokenFile = "/etc/common/spire/tokens/${vmName}.token";
+          attestationMode =
+            if
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            then
+              "tpm_devid"
+            else
+              "join_token";
+        };
+        devidProvision =
+          lib.mkIf
+            (
+              (globalConfig.spiffe.tpmAttestation.enable or false)
+              && ((globalConfig.platform.hostSystem or "") == "x86_64-linux")
+            )
+            {
+              enable = true;
+              inherit vmName;
+            };
+      };
     };
 
     # Common namespace - from hostConfig

--- a/modules/reference/hardware/flake-module.nix
+++ b/modules/reference/hardware/flake-module.nix
@@ -19,6 +19,26 @@
         ghaf.hardware.definition.netvm.extraModules = [
           (import ./alienware/net-config.nix)
         ];
+        # Intel Raptor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-dell-latitude-7230.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7230.nix; }
+      {
+        # Intel Alder Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-dell-latitude-7330.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7330.nix; }
+      {
+        # Intel Tiger Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
       }
     ];
 
@@ -56,6 +76,11 @@
           definition.guivm.extraModules = [
             (import ./intel-laptop/extra-config.nix)
           ];
+          # Generic Intel laptop — Intel PTT fTPM, possibly Infineon dTPM on some SKUs
+          definition.tpm.endorsementCaVendors = [
+            "Intel"
+            "Infineon"
+          ];
         };
       }
     ];
@@ -67,6 +92,68 @@
         # Hardware-specific VM configs via hardware definition
         ghaf.hardware.definition.guivm.extraModules = [
           ./lenovo-t14-amd/gpu-config.nix
+        ];
+        # AMD Ryzen — AMD fTPM or Infineon dTPM depending on SKU
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [
+          "AMD"
+          "Infineon"
+        ];
+      }
+    ];
+
+    hardware-lenovo-x1-2-in-1-gen9.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-2-in-1-gen-9.nix; }
+      {
+        # Intel Meteor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen10.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen10.nix; }
+      {
+        # Intel Alder Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen11.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen11.nix; }
+      {
+        # Intel Raptor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen12.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen12.nix; }
+      {
+        # Intel Meteor Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-lenovo-x1-carbon-gen13.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen13.nix; }
+      {
+        # Intel Lunar Lake — Intel PTT fTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [ "Intel" ];
+      }
+    ];
+
+    hardware-system76-darp11-b.imports = [
+      inputs.self.nixosModules.hardware-x86_64-workstation
+      { ghaf.hardware.definition = import ./system76/definitions/system76-darp11-b.nix; }
+      {
+        # Intel Arrow Lake — Intel PTT fTPM, possibly Infineon dTPM
+        ghaf.hardware.definition.tpm.endorsementCaVendors = [
+          "Intel"
+          "Infineon"
         ];
       }
     ];
@@ -83,62 +170,6 @@
           ];
           passthrough.pci.autoDetectNet = true;
         };
-      }
-    ];
-
-    hardware-dell-latitude-7230.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7230.nix;
-      }
-    ];
-
-    hardware-dell-latitude-7330.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./dell-latitude/definitions/dell-latitude-7330.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-2-in-1-gen9.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-2-in-1-gen-9.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen10.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen10.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen11.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen11.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen12.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen12.nix;
-      }
-    ];
-
-    hardware-lenovo-x1-carbon-gen13.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./lenovo-x1/definitions/x1-gen13.nix;
-      }
-    ];
-
-    hardware-system76-darp11-b.imports = [
-      inputs.self.nixosModules.hardware-x86_64-workstation
-      {
-        ghaf.hardware.definition = import ./system76/definitions/system76-darp11-b.nix;
       }
     ];
 

--- a/overlays/custom-packages/default.nix
+++ b/overlays/custom-packages/default.nix
@@ -20,6 +20,7 @@
   osquery-with-hostname = import ./osquery-with-hostname { inherit prev; };
   papirus-icon-theme = import ./papirus-icon-theme { inherit prev; };
   qemu_kvm = import ./qemu { inherit final prev; };
+  spire = import ./spire { inherit prev; };
   systemd = import ./systemd { inherit prev; };
   tpm2-pkcs11 = import ./tpm2-pkcs11 { inherit prev; };
   tpm2-tools = import ./tpm2-tools { inherit prev; };

--- a/overlays/custom-packages/spire/0001-remove-cloud-components-to-reduce-memory-footprint.patch
+++ b/overlays/custom-packages/spire/0001-remove-cloud-components-to-reduce-memory-footprint.patch
@@ -1,0 +1,145 @@
+From 7c5149a8f8c0e129d1f1c1261bd6a63d7a96ffd1 Mon Sep 17 00:00:00 2001
+From: Ganga Ram <Ganga.Ram@tii.ae>
+Date: Tue, 17 Feb 2026 12:46:42 +0400
+Subject: [PATCH] remove cloud components to reduce memory footprint
+
+Signed-off-by: Ganga Ram <Ganga.Ram@tii.ae>
+---
+ pkg/agent/catalog/nodeattestor.go     | 28 +++++++++++++--------------
+ pkg/agent/catalog/workloadattestor.go | 12 ++++++------
+ pkg/server/catalog/nodeattestor.go    | 28 +++++++++++++--------------
+ 3 files changed, 34 insertions(+), 34 deletions(-)
+
+diff --git a/pkg/agent/catalog/nodeattestor.go b/pkg/agent/catalog/nodeattestor.go
+index 97af6912a..0c8928911 100644
+--- a/pkg/agent/catalog/nodeattestor.go
++++ b/pkg/agent/catalog/nodeattestor.go
+@@ -2,14 +2,14 @@ package catalog
+ 
+ import (
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/awsiid"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azureimds"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azuremsi"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/gcpiit"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/httpchallenge"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/awsiid"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azureimds"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azuremsi"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/gcpiit"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/httpchallenge"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/jointoken"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/k8spsat"
+-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/sshpop"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/k8spsat"
++	//"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/sshpop"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/tpmdevid"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/x509pop"
+ 	"github.com/spiffe/spire/pkg/common/catalog"
+@@ -35,14 +35,14 @@ func (repo *nodeAttestorRepository) Versions() []catalog.Version {
+ 
+ func (repo *nodeAttestorRepository) BuiltIns() []catalog.BuiltIn {
+ 	return []catalog.BuiltIn{
+-		awsiid.BuiltIn(),
+-		azuremsi.BuiltIn(),
+-		azureimds.BuiltIn(),
+-		gcpiit.BuiltIn(),
+-		httpchallenge.BuiltIn(),
++		//awsiid.BuiltIn(),
++		//azuremsi.BuiltIn(),
++		//azureimds.BuiltIn(),
++		//gcpiit.BuiltIn(),
++		//httpchallenge.BuiltIn(),
+ 		jointoken.BuiltIn(),
+-		k8spsat.BuiltIn(),
+-		sshpop.BuiltIn(),
++		//k8spsat.BuiltIn(),
++		//sshpop.BuiltIn(),
+ 		tpmdevid.BuiltIn(),
+ 		x509pop.BuiltIn(),
+ 	}
+diff --git a/pkg/agent/catalog/workloadattestor.go b/pkg/agent/catalog/workloadattestor.go
+index 4e367815b..bbe1a4f60 100644
+--- a/pkg/agent/catalog/workloadattestor.go
++++ b/pkg/agent/catalog/workloadattestor.go
+@@ -2,11 +2,11 @@ package catalog
+ 
+ import (
+ 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
+-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker"
+-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/k8s"
++	//"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker"
++	//"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/k8s"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/systemd"
+ 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/unix"
+-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/windows"
++	//"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/windows"
+ 	"github.com/spiffe/spire/pkg/common/catalog"
+ )
+ 
+@@ -28,11 +28,11 @@ func (repo *workloadAttestorRepository) Versions() []catalog.Version {
+ 
+ func (repo *workloadAttestorRepository) BuiltIns() []catalog.BuiltIn {
+ 	return []catalog.BuiltIn{
+-		docker.BuiltIn(),
+-		k8s.BuiltIn(),
++		//docker.BuiltIn(),
++		//k8s.BuiltIn(),
+ 		systemd.BuiltIn(),
+ 		unix.BuiltIn(),
+-		windows.BuiltIn(),
++		//windows.BuiltIn(),
+ 	}
+ }
+ 
+diff --git a/pkg/server/catalog/nodeattestor.go b/pkg/server/catalog/nodeattestor.go
+index 2e9d540a6..1cc37710d 100644
+--- a/pkg/server/catalog/nodeattestor.go
++++ b/pkg/server/catalog/nodeattestor.go
+@@ -3,14 +3,14 @@ package catalog
+ import (
+ 	"github.com/spiffe/spire/pkg/common/catalog"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/awsiid"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azureimds"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azuremsi"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/gcpiit"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/httpchallenge"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/awsiid"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azureimds"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azuremsi"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/gcpiit"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/httpchallenge"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/jointoken"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/k8spsat"
+-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/sshpop"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/k8spsat"
++	//"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/sshpop"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/tpmdevid"
+ 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/x509pop"
+ )
+@@ -35,14 +35,14 @@ func (repo *nodeAttestorRepository) Versions() []catalog.Version {
+ 
+ func (repo *nodeAttestorRepository) BuiltIns() []catalog.BuiltIn {
+ 	return []catalog.BuiltIn{
+-		awsiid.BuiltIn(),
+-		azuremsi.BuiltIn(),
+-		azureimds.BuiltIn(),
+-		gcpiit.BuiltIn(),
+-		httpchallenge.BuiltIn(),
++		//awsiid.BuiltIn(),
++		//azuremsi.BuiltIn(),
++		//azureimds.BuiltIn(),
++		//gcpiit.BuiltIn(),
++		//httpchallenge.BuiltIn(),
+ 		jointoken.BuiltIn(),
+-		k8spsat.BuiltIn(),
+-		sshpop.BuiltIn(),
++		//k8spsat.BuiltIn(),
++		//sshpop.BuiltIn(),
+ 		tpmdevid.BuiltIn(),
+ 		x509pop.BuiltIn(),
+ 	}
+-- 
+2.51.2
+

--- a/overlays/custom-packages/spire/default.nix
+++ b/overlays/custom-packages/spire/default.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{ prev }:
+prev.spire.overrideAttrs (_oldAttrs: {
+  patches = [
+    ./0001-remove-cloud-components-to-reduce-memory-footprint.patch
+  ];
+})

--- a/packages/own-pkgs-overlay.nix
+++ b/packages/own-pkgs-overlay.nix
@@ -23,6 +23,7 @@
     memsocket = final.callPackage ./pkgs-by-name/memsocket/package.nix { };
     pci-binder = final.callPackage ./pkgs-by-name/pci-binder/package.nix { };
     rtl8126 = final.callPackage ./pkgs-by-name/rtl8126/package.nix { };
+    tpm-endorsement-certs = final.callPackage ./pkgs-by-name/tpm-endorsement-certs/package.nix { };
     update-docs-depends = final.callPackage ./pkgs-by-name/update-docs-depends/package.nix { };
     user-provision = final.callPackage ./pkgs-by-name/user-provision/package.nix { };
     wait-for-unit = final.callPackage ./pkgs-by-name/wait-for-unit/package.nix { };

--- a/packages/pkgs-by-name/tpm-endorsement-certs/package.nix
+++ b/packages/pkgs-by-name/tpm-endorsement-certs/package.nix
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# TPM Endorsement CA Certificates Package
+#
+# Downloads Microsoft's TrustedTpm.cab (containing root and intermediate CA
+# certificates from all approved TPM manufacturers) and produces per-vendor
+# PEM bundles. These are used by SPIRE's tpm_devid NodeAttestor to verify
+# that DevID keys reside in genuine TPMs.
+#
+# Output: $out/vendors/{AMD,Intel,Infineon,...}.pem and $out/all.pem
+#
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  cabextract,
+  openssl,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "tpm-endorsement-certs";
+  version = "2025-08-29"; # Date from cab contents
+
+  src = fetchurl {
+    url = "https://go.microsoft.com/fwlink/?linkid=2097925";
+    name = "TrustedTpm.cab";
+    hash = "sha256-tTmMgD3Ahj12rqccVbkmdiAz6RfD031Vp0Zsso1h2CY=";
+  };
+
+  dontUnpack = true;
+  nativeBuildInputs = [
+    cabextract
+    openssl
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir extracted
+    cabextract -d extracted "$src"
+    mkdir -p $out/vendors
+
+    for vendor_dir in extracted/*/; do
+      [ -d "$vendor_dir" ] || continue
+      vendor_name=$(basename "$vendor_dir")
+
+      # Skip non-vendor directories
+      case "$vendor_name" in
+        setup.*|*.txt|*.cmd|*.ps1) continue ;;
+      esac
+
+      pem_content=""
+
+      # Find all cert files in vendor dir (root + intermediate)
+      while IFS= read -r -d "" cert; do
+        # Try DER first (most common), fall back to PEM
+        converted=$(openssl x509 -inform DER -in "$cert" -outform PEM 2>/dev/null || \
+                    openssl x509 -inform PEM -in "$cert" -outform PEM 2>/dev/null || true)
+        if [ -n "$converted" ]; then
+          pem_content="$pem_content$converted"$'\n'
+        else
+          echo "WARNING: Could not convert $cert" >&2
+        fi
+      done < <(find "$vendor_dir" -type f \( -iname "*.cer" -o -iname "*.crt" -o -iname "*.der" \) -print0)
+
+      if [ -n "$pem_content" ]; then
+        printf '%s' "$pem_content" > "$out/vendors/$vendor_name.pem"
+        cert_count=$(grep -c 'BEGIN CERTIFICATE' "$out/vendors/$vendor_name.pem" || true)
+        echo "Wrote $cert_count certs for $vendor_name"
+      fi
+    done
+
+    # Combined all-vendors PEM
+    cat $out/vendors/*.pem > $out/all.pem
+    total=$(grep -c 'BEGIN CERTIFICATE' "$out/all.pem" || true)
+    echo "Total: $total certs across all vendors"
+
+    runHook postBuild
+  '';
+
+  # Everything is done in buildPhase writing directly to $out
+  installPhase = "true";
+
+  meta = {
+    description = "TPM manufacturer endorsement CA certificates from Microsoft TrustedTpm.cab";
+    homepage = "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/component-updates/tpm-key-attestation";
+    license = lib.licenses.unfree; # Microsoft-distributed manufacturer certificates
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- remove the TPM hierarchy debug monitor regression source and keep TPM enrollment/provisioning on host resource-manager path.
- harden SPIFFE DevID provisioning and CA signing flow (blob normalization, request/cert validation, robust public-key request signing).
- align SPIRE TPM DevID runtime access to `/dev/tpm0` in guests and add TPM device udev permissions for system VMs.

## Validation Result
- `net-vm`: `spire-devid-provision` completed and `spire-agent` reached `Node attestation was successful` with `tpm_devid`.
- `audio-vm`: `spire-devid-provision` completed and `spire-agent` reached `Node attestation was successful` with `tpm_devid`.
- `gui-vm`: reprovisioned cleanly after transient load/integrity failures; `spire-agent` reached `Node attestation was successful` with `tpm_devid`.
- commit hooks passed during commit creation (`reuse`, `treefmt`, `trim-trailing-whitespace`, `end-of-file-fixer`).

## Comprehensive Testing Instructions
### 1) Build Image
```bash
docker compose up -d
docker compose exec --user dev -w /workspace/ghaf-mainline nixos-dev bash -lc \
  "git checkout tpm-case-C && nix build .#lenovo-x1-carbon-gen11-debug"
```

### 2) Boot Device
- Flash/boot `lenovo-x1-carbon-gen11-debug` with this branch build.
- Wait until `ghaf-host`, `net-vm`, `gui-vm`, `audio-vm`, and `admin-vm` are reachable.

### 3) Check TPM Health on Host
```bash
ssh -J ghaf@<netvm-lan-ip> ghaf@192.168.100.2 \
  'tpm2_getcap properties-variable | grep -E "TPM2_PT_HR_(ACTIVE|LOADED|TRANSIENT_AVAIL)"'
```
Expected: `TRANSIENT_AVAIL` remains non-zero and no repeated timeout storms in logs.

### 4) Verify DevID Provisioning in Each System VM
```bash
# net-vm
ssh ghaf@<netvm-lan-ip> 'systemctl is-active spire-devid-provision spire-agent; cat /run/tpm/devid-status; journalctl -u spire-devid-provision -n 80 --no-pager'

# gui-vm
ssh -J ghaf@<netvm-lan-ip> ghaf@192.168.100.4 'systemctl is-active spire-devid-provision spire-agent; cat /run/tpm/devid-status; journalctl -u spire-devid-provision -n 80 --no-pager'

# audio-vm
ssh -J ghaf@<netvm-lan-ip> ghaf@192.168.100.3 'systemctl is-active spire-devid-provision spire-agent; cat /run/tpm/devid-status; journalctl -u spire-devid-provision -n 80 --no-pager'
```
Expected: `spire-devid-provision` exits successfully and `/run/tpm/devid-status` is `ready`.

### 5) Verify SPIRE TPM DevID Attestation
```bash
# net-vm
ssh ghaf@<netvm-lan-ip> 'journalctl -u spire-agent -n 200 --no-pager | grep -E "tpm_devid|Node attestation was successful|Failed to retrieve attestation result"'

# gui-vm
ssh -J ghaf@<netvm-lan-ip> ghaf@192.168.100.4 'journalctl -u spire-agent -n 200 --no-pager | grep -E "tpm_devid|Node attestation was successful|Failed to retrieve attestation result"'

# audio-vm
ssh -J ghaf@<netvm-lan-ip> ghaf@192.168.100.3 'journalctl -u spire-agent -n 200 --no-pager | grep -E "tpm_devid|Node attestation was successful|Failed to retrieve attestation result"'
```
Expected: eventual `Node attestation was successful` with `tpm_devid` for all three VMs.

### 6) Verify DevID Signer (admin-vm)
```bash
ssh -J ghaf@<netvm-lan-ip> ghaf@192.168.100.5 \
  'journalctl -u spire-devid-sign -n 120 --no-pager; ls -l /etc/common/spire/devid/requests /etc/common/spire/devid/certs'
```
Expected: signer processes requests and writes non-empty certs.

### 7) Optional Recovery for a Single VM (if transient failure occurs)
```bash
# Example for gui-vm
ssh -J ghaf@<netvm-lan-ip> ghaf@192.168.100.4 '
  echo ghaf | sudo -S sh -c "
    systemctl stop spire-agent spire-devid-provision;
    rm -f /var/lib/spire/devid/devid.priv /var/lib/spire/devid/devid.pub /var/lib/spire/devid/devid.pem \
          /var/lib/spire/devid/devid.ctx /var/lib/spire/devid/primary.ctx /var/lib/spire/devid/devid.tss.pub \
          /var/lib/spire/devid/devid-pub.pem /run/tpm/devid-status \
          /etc/common/spire/devid/requests/gui-vm.pub.pem /etc/common/spire/devid/certs/gui-vm.pem;
    systemctl start spire-devid-provision;
    systemctl start spire-agent;
  "'
```

## Notes
- this branch includes the SPIFFE TPM DevID feature commits from PR #1771 plus stabilization/fix commits validated on hardware.