### PR TITLE
givc: integrate SPIFFE TLS certificate distribution

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -260,7 +260,14 @@ export default defineConfig({
               items: [
                 {
                   label: "Overview",
-                  items: ["givc/overview", "givc/overview/arch"],
+                  items: [
+                    "givc/overview",
+                    "givc/overview/arch",
+                    {
+                      label: "SPIFFE Certificate Distribution",
+                      link: "/givc/overview/spiffe-givc-cert-distribution/",
+                    },
+                  ],
                 },
                 {
                   label: "Getting Started",

--- a/docs/src/content/docs/givc/overview/spiffe-givc-cert-distribution.mdx
+++ b/docs/src/content/docs/givc/overview/spiffe-givc-cert-distribution.mdx
@@ -1,0 +1,263 @@
+---
+title: SPIFFE Certificate Distribution for GIVC
+description: End-to-end design and operations guide for SPIFFE-based GIVC identity and certificate distribution.
+---
+{/*
+SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+*/}
+
+# SPIFFE Certificate Distribution for GIVC
+
+This document explains how Ghaf distributes and uses GIVC TLS identities in SPIFFE mode.
+It also documents the static TLS path, startup dependencies, configuration propagation, and troubleshooting.
+
+## Scope
+
+This page covers:
+
+- GIVC TLS modes (`none`, `static`, `spiffe`)
+- How certificates or SVIDs are obtained in each mode
+- How host and VM configuration is propagated
+- Operational checks to confirm the system is healthy
+- Common failure signatures and fixes
+
+This page does not cover the full SPIRE policy model in depth. It focuses on GIVC integration.
+
+## Why This Feature Exists
+
+Historically, GIVC used static PEM files mounted into VMs. That model works, but it requires key material generation and distribution via host-managed storage.
+
+SPIFFE mode replaces static cert distribution with workload-issued identities:
+
+- Each workload obtains an X.509-SVID from the local SPIRE agent
+- Trust anchors come from SPIFFE bundles
+- GIVC services authenticate peers using SPIFFE identities
+
+Benefits:
+
+- No long-lived static cert/key files required for GIVC runtime
+- Identity lifecycle can be managed by SPIRE
+- Clear trust domain and workload identity semantics
+
+## TLS Modes
+
+GIVC currently supports three modes:
+
+| Mode | Behavior | Typical Use |
+| --- | --- | --- |
+| `none` | No TLS for GIVC transport | Local/dev testing only |
+| `static` | PEM files (`ca-cert.pem`, `cert.pem`, `key.pem`) | Legacy/default compatibility |
+| `spiffe` | X.509-SVID and bundle from SPIRE Workload API | Preferred secure deployment |
+
+## High-Level Architecture
+
+### Static TLS path
+
+In static mode, host-side services generate or stage cert/key material and distribute it through VM storage/share mechanisms.
+
+Key characteristics:
+
+- Boot ordering depends on static key setup units
+- VM services read certs from `/etc/givc/*.pem` or staged equivalents
+- Missing static files break GIVC startup
+
+### SPIFFE TLS path
+
+In SPIFFE mode, workloads use the local SPIRE agent socket:
+
+- Endpoint: `unix:///run/spire/agent.sock`
+- Trust domain: usually `ghaf.internal`
+- Identities: issued as X.509-SVIDs
+
+GIVC components fetch identity material from SPIRE at runtime and build TLS configurations from SVID + bundle data.
+
+## Certificate/SVID Distribution Flow (SPIFFE)
+
+1. `admin-vm` runs SPIRE server and generates join tokens for host/system/app VMs.
+2. Tokens are distributed through the shared persistent path (for example `/persist/common/spire/tokens`).
+3. Each VM and host runs `spire-agent` and attests using its configured mode.
+4. GIVC services connect to local Workload API (`/run/spire/agent.sock`) and request identity material.
+5. GIVC server/client TLS stacks are built from returned SVIDs and trust bundles.
+6. GIVC control plane communication (host/sysvm/appvm/admin) uses mTLS with SPIFFE-derived credentials.
+
+## Runtime Components and Responsibilities
+
+- `givc-agent` (Go): host/sysvm/appvm GIVC transport and capability service
+- `givc-admin` (Rust): admin service and policy/control plane endpoint
+- `spire-server` (admin-vm): CA and registration authority
+- `spire-agent` (host + VMs): local workload identity source
+
+## Configuration Model
+
+### Primary Ghaf settings
+
+Set GIVC TLS mode at target/host configuration level:
+
+```nix
+ghaf.givc.tls.mode = "spiffe";
+ghaf.givc.tls.spiffeSocketPath = "unix:///run/spire/agent.sock";
+ghaf.givc.tls.trustDomain = "ghaf.internal";
+ghaf.givc.tls.allowedIDs = [ ];
+```
+
+SPIFFE framework should also be enabled:
+
+```nix
+ghaf.global-config.spiffe.enable = true;
+ghaf.global-config.spiffe.trustDomain = "ghaf.internal";
+```
+
+### Propagation model (host to VMs)
+
+Ghaf VM composition uses `globalConfig` and `hostConfig`.
+
+Important detail for GIVC TLS:
+
+- VM base modules must consume propagated host-side GIVC TLS via `hostConfig.givc.tls`
+- Relying on VM-local defaults can incorrectly revert to `static`
+
+When propagation is correct, `/etc/givc-agent/config.json` in host and VMs should all show `"mode":"spiffe"`.
+
+## Boot Ordering and Dependencies
+
+### Static mode requirements
+
+Static mode can require units such as key-setup and static cert image paths.
+
+### SPIFFE mode requirements
+
+SPIFFE mode should avoid static-cert prerequisites and instead require:
+
+- SPIRE token availability
+- SPIRE agent startup
+- Admin-vm SPIRE server and entry generation flow
+
+If static dependencies are left enabled in SPIFFE mode, VM startup can fail even though SPIFFE itself is configured.
+
+## Service-Level Health Checks
+
+Use these checks after boot.
+
+### 1) Confirm mode everywhere
+
+Check host and each relevant VM:
+
+```bash
+cat /etc/givc-agent/config.json
+```
+
+Expected:
+
+- `network.tls.mode` is `spiffe`
+- `network.tls.spiffeEndpoint` is `unix:///run/spire/agent.sock`
+- `network.tls.trustDomain` matches deployment trust domain
+
+### 2) Confirm GIVC services
+
+```bash
+systemctl status givc-ghaf-host.service
+systemctl status givc-admin.service
+systemctl status givc-admin-vm.service
+systemctl status givc-net-vm.service
+```
+
+Expected: active/running on relevant nodes.
+
+### 3) Confirm SPIRE agents
+
+```bash
+systemctl status spire-agent.service
+journalctl -u spire-agent.service -n 100 --no-pager
+```
+
+Expected:
+
+- agent attestation success
+- Workload API socket started
+
+### 4) Confirm token generation path
+
+```bash
+ls -l /persist/common/spire/tokens
+```
+
+Expected token files for host and VMs.
+
+## Common Failure Signatures
+
+### `open /etc/givc/cert.pem: no such file or directory`
+
+Meaning:
+
+- Service is still in `static` mode but static PEMs are not present
+
+Typical causes:
+
+- TLS mode not propagated into VM-local GIVC config
+- Mixed host/VM config where host is SPIFFE but VM remains static
+
+### Missing `/persist/common/spire/tokens/<node>.token`
+
+Meaning:
+
+- SPIRE join token generation/distribution did not complete before agent start
+
+Typical causes:
+
+- `admin-vm` SPIRE services not running
+- boot sequencing or upstream VM startup failure
+
+### VM fails with missing `/persist/storagevm/givc/<vm>.img`
+
+Meaning:
+
+- Static cert storage path is still required in SPIFFE mode
+
+Typical causes:
+
+- static TLS storage ordering/mount logic not correctly gated by TLS mode
+
+### `No identity issued` in SPIRE agent logs
+
+Meaning:
+
+- Workload API request does not match a SPIRE registration entry yet
+
+Notes:
+
+- May appear briefly during startup
+- Persistent messages indicate missing or incorrect workload registration/selectors
+
+## Migration Notes (Static to SPIFFE)
+
+When migrating an existing target:
+
+1. Set `ghaf.givc.tls.mode = "spiffe"`.
+2. Enable SPIFFE and align trust domain values.
+3. Ensure static key/cert service dependencies are disabled for SPIFFE mode.
+4. Ensure VM GIVC config inherits host TLS mode.
+5. Rebuild and verify `config.json` mode across host and VMs.
+
+## Security Notes
+
+- `allowedIDs` can be used to restrict accepted peer identities.
+- Trust domain consistency is critical (`ghaf.internal` or deployment-specific domain).
+- SPIFFE mode should avoid distributing long-lived private keys via shared files.
+
+## Validation Checklist
+
+Use this as release readiness criteria for the SPIFFE GIVC path:
+
+- Host GIVC mode is `spiffe`
+- Admin VM GIVC mode is `spiffe`
+- System VM GIVC mode is `spiffe`
+- `givc-admin` and all required `givc-agent` services are running
+- `spire-agent` running on host and VMs
+- Join tokens present and consumed successfully
+- No static cert path dependency errors in journals
+
+## Related Pages
+
+- [`/givc/overview/arch`](/givc/overview/arch/)
+- [`/ghaf/dev/architecture/config-propagation`](/ghaf/dev/architecture/config-propagation/)

--- a/flake.lock
+++ b/flake.lock
@@ -376,15 +376,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769692703,
-        "narHash": "sha256-5waDbPvk0Pf0E63cDkEJRPA2DOKAUjiZHiaNSpn1wls=",
-        "owner": "tiiuae",
+        "lastModified": 1772644735,
+        "narHash": "sha256-TqE7QgTfRDXKbc14l+MN7KsDwMpzVjJydtgnKOyiGII=",
+        "owner": "vadika",
         "repo": "ghaf-givc",
-        "rev": "5731cbae603f1a29737526366a6e931680c3dd84",
+        "rev": "06cd10c39ca18b3f648656c3290fb9f13ea84f4d",
         "type": "github"
       },
       "original": {
-        "owner": "tiiuae",
+        "owner": "vadika",
+        "ref": "vadika/ghaf-givc-spiffe",
         "repo": "ghaf-givc",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
 
     # Ghaf Inter VM communication and control library
     givc = {
-      url = "github:tiiuae/ghaf-givc";
+      url = "github:vadika/ghaf-givc/vadika/ghaf-givc-spiffe";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/lib/global-config.nix
+++ b/lib/global-config.nix
@@ -689,7 +689,13 @@ rec {
         # GIVC configuration
         givc = {
           cliArgs = config.ghaf.givc.cliArgs or "";
-          enableTls = config.ghaf.givc.enableTls or false;
+          enableTls = (config.ghaf.givc.tls.mode or "none") == "static";
+          tls = {
+            mode = config.ghaf.givc.tls.mode or "static";
+            spiffeSocketPath = config.ghaf.givc.tls.spiffeSocketPath or "unix:///run/spire/agent.sock";
+            trustDomain = config.ghaf.givc.tls.trustDomain or "ghaf.internal";
+            allowedIDs = config.ghaf.givc.tls.allowedIDs or [ ];
+          };
         };
 
         # Security settings (SSH keys, etc.)

--- a/modules/common/services/yubikey.nix
+++ b/modules/common/services/yubikey.nix
@@ -59,6 +59,6 @@ in
       ACTION=="remove", ENV{ID_BUS}=="usb", ENV{ID_VENDOR_ID}=="1050", ENV{ID_MODEL_ID}=="0407", RUN+="${pkgs.systemd}/bin/loginctl lock-sessions"
     '';
 
-    givc.sysvm.enableCtapModule = true;
+    givc.sysvm.capabilities.ctap.enable = true;
   };
 }

--- a/modules/desktop/guivm/boot-ui.nix
+++ b/modules/desktop/guivm/boot-ui.nix
@@ -51,7 +51,7 @@ in
 
   config = lib.mkIf bootEnabled {
     # Allow systemd units to be monitored via givc
-    givc.sysvm.services = [
+    givc.sysvm.capabilities.services = lib.mkAfter [
       "greetd.service"
       "user-login.service"
     ];

--- a/modules/givc/adminvm.nix
+++ b/modules/givc/adminvm.nix
@@ -7,6 +7,11 @@ let
   inherit (config.ghaf.givc.adminConfig) name;
   inherit (config.ghaf.networking) hosts;
   inherit (config.networking) hostName;
+  tlsMode = config.ghaf.global-config.givc.tls.mode or config.ghaf.givc.tls.mode;
+  tlsSpiffeSocketPath =
+    config.ghaf.global-config.givc.tls.spiffeSocketPath or config.ghaf.givc.tls.spiffeSocketPath;
+  tlsTrustDomain = config.ghaf.global-config.givc.tls.trustDomain or config.ghaf.givc.tls.trustDomain;
+  tlsAllowedIDs = config.ghaf.global-config.givc.tls.allowedIDs or config.ghaf.givc.tls.allowedIDs;
   systemHosts = lib.lists.subtractLists (config.ghaf.common.appHosts ++ [ name ]) (
     builtins.attrNames config.ghaf.networking.hosts
   );
@@ -26,23 +31,37 @@ in
       inherit name;
       inherit (config.ghaf.givc.adminConfig) addresses;
       services = map (host: "givc-${host}.service") systemHosts;
-      tls.enable = config.ghaf.givc.enableTls;
+      tls = {
+        enable = tlsMode != "none";
+        mode = tlsMode;
+        spiffeEndpoint = tlsSpiffeSocketPath;
+        trustDomain = tlsTrustDomain;
+        allowedIDs = tlsAllowedIDs;
+      };
     };
     # Sysvm agent so admin-vm receives timezone/locale propagation
     givc.sysvm = {
       enable = true;
       inherit (config.ghaf.givc) debug;
-      transport = {
-        name = hostName;
-        addr = hosts.${hostName}.ipv4;
-        port = "9000";
+      network = {
+        agent.transport = {
+          name = hostName;
+          addr = hosts.${hostName}.ipv4;
+          port = "9000";
+        };
+        admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
+        tls = {
+          enable = tlsMode != "none";
+          mode = tlsMode;
+          spiffeEndpoint = tlsSpiffeSocketPath;
+          trustDomain = tlsTrustDomain;
+          allowedIDs = tlsAllowedIDs;
+        };
       };
-      services = [
+      capabilities.services = [
         "poweroff.target"
         "reboot.target"
       ];
-      tls.enable = config.ghaf.givc.enableTls;
-      admin = lib.head config.ghaf.givc.adminConfig.addresses;
     };
     ghaf.security.audit.extraRules = [
       "-w /etc/givc/ -p wa -k givc-${name}"

--- a/modules/givc/appvm.nix
+++ b/modules/givc/appvm.nix
@@ -15,6 +15,11 @@ let
     ;
   inherit (config.ghaf.networking) hosts;
   inherit (config.networking) hostName;
+  tlsMode = config.ghaf.global-config.givc.tls.mode or config.ghaf.givc.tls.mode;
+  tlsSpiffeSocketPath =
+    config.ghaf.global-config.givc.tls.spiffeSocketPath or config.ghaf.givc.tls.spiffeSocketPath;
+  tlsTrustDomain = config.ghaf.global-config.givc.tls.trustDomain or config.ghaf.givc.tls.trustDomain;
+  tlsAllowedIDs = config.ghaf.global-config.givc.tls.allowedIDs or config.ghaf.givc.tls.allowedIDs;
 in
 {
   _file = ./appvm.nix;
@@ -34,14 +39,24 @@ in
       enable = true;
       inherit (config.ghaf.givc) debug;
       inherit (config.ghaf.users.homedUser) uid;
-      transport = {
-        name = hostName;
-        addr = hosts.${hostName}.ipv4;
-        port = "9000";
+      network = {
+        agent.transport = {
+          name = hostName;
+          addr = hosts.${hostName}.ipv4;
+          port = "9000";
+        };
+        admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
+        tls = {
+          enable = tlsMode != "none";
+          mode = tlsMode;
+          spiffeEndpoint = tlsSpiffeSocketPath;
+          trustDomain = tlsTrustDomain;
+          allowedIDs = tlsAllowedIDs;
+        };
       };
-      inherit (cfg) applications;
-      tls.enable = config.ghaf.givc.enableTls;
-      admin = lib.head config.ghaf.givc.adminConfig.addresses;
+      capabilities = {
+        inherit (cfg) applications;
+      };
     };
     ghaf.security.audit.extraRules = [
       "-w /etc/givc/ -p wa -k givc-${hostName}"

--- a/modules/givc/audiovm.nix
+++ b/modules/givc/audiovm.nix
@@ -16,6 +16,11 @@ let
   guivmName = "gui-vm";
   inherit (config.ghaf.networking) hosts;
   inherit (config.networking) hostName;
+  tlsMode = config.ghaf.global-config.givc.tls.mode or config.ghaf.givc.tls.mode;
+  tlsSpiffeSocketPath =
+    config.ghaf.global-config.givc.tls.spiffeSocketPath or config.ghaf.givc.tls.spiffeSocketPath;
+  tlsTrustDomain = config.ghaf.global-config.givc.tls.trustDomain or config.ghaf.givc.tls.trustDomain;
+  tlsAllowedIDs = config.ghaf.global-config.givc.tls.allowedIDs or config.ghaf.givc.tls.allowedIDs;
 in
 {
   _file = ./audiovm.nix;
@@ -29,53 +34,69 @@ in
     givc.sysvm = {
       enable = true;
       inherit (config.ghaf.givc) debug;
-      transport = {
-        name = hostName;
-        addr = hosts.${hostName}.ipv4;
-        port = "9000";
+      network = {
+        agent.transport = {
+          name = hostName;
+          addr = hosts.${hostName}.ipv4;
+          port = "9000";
+        };
+        admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
+        tls = {
+          enable = tlsMode != "none";
+          mode = tlsMode;
+          spiffeEndpoint = tlsSpiffeSocketPath;
+          trustDomain = tlsTrustDomain;
+          allowedIDs = tlsAllowedIDs;
+        };
       };
-      tls.enable = config.ghaf.givc.enableTls;
-      admin = lib.head config.ghaf.givc.adminConfig.addresses;
-      services = [
-        "poweroff.target"
-        "reboot.target"
-      ]
-      ++ optionals config.ghaf.services.power-manager.vm.enable [
-        "suspend.target"
-        "systemd-suspend.service"
-      ];
-      socketProxy = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
-        {
-          transport = {
-            name = guivmName;
-            addr = hosts.${guivmName}.ipv4;
-            port = "9011";
-            protocol = "tcp";
-          };
-          socket = "/tmp/dbusproxy_snd.sock";
-        }
-        (lib.optionalAttrs (audioCfg.enable && audioCfg.server.pipewireForwarding.enable) {
-          transport = {
-            name = guivmName;
-            addr = hosts.${guivmName}.ipv4;
-            inherit (audioCfg.server.pipewireForwarding) port;
-            protocol = "tcp";
-          };
-          inherit (audioCfg.server.pipewireForwarding) socket;
-        })
-      ];
-      eventProxy = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
-        {
-          transport = {
-            name = guivmName;
-            addr = hosts.${guivmName}.ipv4;
-            port = "9012";
-            protocol = "tcp";
-          };
-          producer = true;
-          device = "mouse";
-        }
-      ];
+      capabilities = {
+        services = [
+          "poweroff.target"
+          "reboot.target"
+        ]
+        ++ optionals config.ghaf.services.power-manager.vm.enable [
+          "suspend.target"
+          "systemd-suspend.service"
+        ];
+        socketProxy = {
+          sockets = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
+            {
+              transport = {
+                name = guivmName;
+                addr = hosts.${guivmName}.ipv4;
+                port = "9011";
+                protocol = "tcp";
+              };
+              socket = "/tmp/dbusproxy_snd.sock";
+            }
+            (lib.optionalAttrs (audioCfg.enable && audioCfg.server.pipewireForwarding.enable) {
+              transport = {
+                name = guivmName;
+                addr = hosts.${guivmName}.ipv4;
+                inherit (audioCfg.server.pipewireForwarding) port;
+                protocol = "tcp";
+              };
+              inherit (audioCfg.server.pipewireForwarding) socket;
+            })
+          ];
+          enable = builtins.elem guivmName config.ghaf.common.vms;
+        };
+        eventProxy = {
+          events = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
+            {
+              transport = {
+                name = guivmName;
+                addr = hosts.${guivmName}.ipv4;
+                port = "9012";
+                protocol = "tcp";
+              };
+              producer = true;
+              device = "mouse";
+            }
+          ];
+          enable = builtins.elem guivmName config.ghaf.common.vms;
+        };
+      };
     };
     givc.dbusproxy = {
       enable = true;

--- a/modules/givc/common.nix
+++ b/modules/givc/common.nix
@@ -10,6 +10,7 @@ let
   inherit (lib)
     mkOption
     mkEnableOption
+    mkDefault
     mkIf
     types
     optionalString
@@ -55,6 +56,32 @@ in
       description = "Enable TLS for gRPC communication globally, or disable for debugging.";
       type = types.bool;
       default = true;
+    };
+    tls = {
+      mode = mkOption {
+        description = "TLS mode for GIVC endpoints: static, spiffe, or none.";
+        type = types.enum [
+          "static"
+          "spiffe"
+          "none"
+        ];
+        default = "static";
+      };
+      spiffeSocketPath = mkOption {
+        description = "SPIFFE Workload API socket endpoint URI.";
+        type = types.str;
+        default = "unix:///run/spire/agent.sock";
+      };
+      trustDomain = mkOption {
+        description = "SPIFFE trust domain used by GIVC workloads.";
+        type = types.str;
+        default = "ghaf.internal";
+      };
+      allowedIDs = mkOption {
+        description = "Allowed SPIFFE IDs for peer authorization.";
+        type = types.listOf types.str;
+        default = [ ];
+      };
     };
     idsExtraArgs = mkOption {
       description = "Extra arguments for applications when IDS/MITM is enabled.";
@@ -110,16 +137,35 @@ in
       in
       {
         inherit idsExtraArgs;
+        tls = {
+          mode = mkDefault (config.ghaf.global-config.givc.tls.mode or "static");
+          spiffeSocketPath = mkDefault (
+            config.ghaf.global-config.givc.tls.spiffeSocketPath or "unix:///run/spire/agent.sock"
+          );
+          trustDomain = mkDefault (config.ghaf.global-config.givc.tls.trustDomain or "ghaf.internal");
+          allowedIDs = mkDefault (config.ghaf.global-config.givc.tls.allowedIDs or [ ]);
+        };
+        enableTls = mkDefault (config.ghaf.givc.tls.mode == "static");
         appPrefix = "/run/current-system/sw/bin";
-        cliArgs = builtins.replaceStrings [ "\n" ] [ " " ] ''
-          --name ${adminAddress.name}
-          --addr ${adminAddress.addr}
-          --port ${adminAddress.port}
-          ${optionalString config.ghaf.givc.enableTls "--cacert /run/givc/ca-cert.pem"}
-          ${optionalString config.ghaf.givc.enableTls "--cert /run/givc/cert.pem"}
-          ${optionalString config.ghaf.givc.enableTls "--key /run/givc/key.pem"}
-          ${optionalString (!config.ghaf.givc.enableTls) "--notls"}
-        '';
+        cliArgs =
+          if config.ghaf.givc.tls.mode == "spiffe" then
+            builtins.replaceStrings [ "\n" ] [ " " ] ''
+              --name ${adminAddress.name}
+              --addr ${adminAddress.addr}
+              --port ${adminAddress.port}
+              --spiffe-endpoint ${config.ghaf.givc.tls.spiffeSocketPath}
+              --trust-domain ${config.ghaf.givc.tls.trustDomain}
+            ''
+          else
+            builtins.replaceStrings [ "\n" ] [ " " ] ''
+              --name ${adminAddress.name}
+              --addr ${adminAddress.addr}
+              --port ${adminAddress.port}
+              ${optionalString (config.ghaf.givc.tls.mode == "static") "--cacert /run/givc/ca-cert.pem"}
+              ${optionalString (config.ghaf.givc.tls.mode == "static") "--cert /run/givc/cert.pem"}
+              ${optionalString (config.ghaf.givc.tls.mode == "static") "--key /run/givc/key.pem"}
+              ${optionalString (config.ghaf.givc.tls.mode == "none") "--notls"}
+            '';
         # Givc admin server configuration
         adminConfig = {
           inherit (adminAddress) name;

--- a/modules/givc/guivm.nix
+++ b/modules/givc/guivm.nix
@@ -18,6 +18,11 @@ let
   guivmName = "gui-vm";
   inherit (config.ghaf.networking) hosts;
   inherit (config.networking) hostName;
+  tlsMode = config.ghaf.global-config.givc.tls.mode or config.ghaf.givc.tls.mode;
+  tlsSpiffeSocketPath =
+    config.ghaf.global-config.givc.tls.spiffeSocketPath or config.ghaf.givc.tls.spiffeSocketPath;
+  tlsTrustDomain = config.ghaf.global-config.givc.tls.trustDomain or config.ghaf.givc.tls.trustDomain;
+  tlsAllowedIDs = config.ghaf.global-config.givc.tls.allowedIDs or config.ghaf.givc.tls.allowedIDs;
 in
 {
   _file = ./guivm.nix;
@@ -31,62 +36,80 @@ in
     givc.sysvm = {
       enable = true;
       inherit (config.ghaf.givc) debug;
-      transport = {
-        name = hostName;
-        addr = hosts.${hostName}.ipv4;
-        port = "9000";
+      network = {
+        agent.transport = {
+          name = hostName;
+          addr = hosts.${hostName}.ipv4;
+          port = "9000";
+        };
+        admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
+        tls = {
+          enable = tlsMode != "none";
+          mode = tlsMode;
+          spiffeEndpoint = tlsSpiffeSocketPath;
+          trustDomain = tlsTrustDomain;
+          allowedIDs = tlsAllowedIDs;
+        };
       };
-      services = [
-        "reboot.target"
-        "poweroff.target"
-      ];
-      admin = lib.head config.ghaf.givc.adminConfig.addresses;
-      tls.enable = config.ghaf.givc.enableTls;
+      capabilities = {
+        services = [
+          "reboot.target"
+          "poweroff.target"
+        ];
+        socketProxy = {
+          sockets =
+            lib.optionals (builtins.elem netvmName config.ghaf.common.vms) [
+              {
+                transport = {
+                  name = netvmName;
+                  addr = hosts.${netvmName}.ipv4;
+                  port = "9010";
+                  protocol = "tcp";
+                };
+                socket = "/tmp/dbusproxy_net.sock";
+              }
+            ]
+            ++ lib.optionals (builtins.elem audiovmName config.ghaf.common.vms) [
+              {
+                transport = {
+                  name = audiovmName;
+                  addr = hosts.${audiovmName}.ipv4;
+                  port = "9011";
+                  protocol = "tcp";
+                };
+                socket = "/tmp/dbusproxy_snd.sock";
+              }
+              (lib.optionalAttrs (audioCfg.enable && audioCfg.client.pipewireControl.enable) {
+                transport = {
+                  name = audiovmName;
+                  addr = hosts.${audiovmName}.ipv4;
+                  inherit (audioCfg.server.pipewireForwarding) port;
+                  protocol = "tcp";
+                };
+                inherit (audioCfg.client.pipewireControl) socket;
+              })
+            ];
+          enable =
+            (builtins.elem netvmName config.ghaf.common.vms)
+            || (builtins.elem audiovmName config.ghaf.common.vms);
+        };
+        eventProxy = {
+          enable = true;
+          events = [
+            {
+              transport = {
+                name = guivmName;
+                addr = hosts.${guivmName}.ipv4;
+                port = "9012";
+                protocol = "tcp";
+              };
+              producer = false;
+            }
+          ];
+        };
+      };
       enableUserTlsAccess = true;
       notifier.enable = true;
-      socketProxy =
-        lib.optionals (builtins.elem netvmName config.ghaf.common.vms) [
-          {
-            transport = {
-              name = netvmName;
-              addr = hosts.${netvmName}.ipv4;
-              port = "9010";
-              protocol = "tcp";
-            };
-            socket = "/tmp/dbusproxy_net.sock";
-          }
-        ]
-        ++ lib.optionals (builtins.elem audiovmName config.ghaf.common.vms) [
-          {
-            transport = {
-              name = audiovmName;
-              addr = hosts.${audiovmName}.ipv4;
-              port = "9011";
-              protocol = "tcp";
-            };
-            socket = "/tmp/dbusproxy_snd.sock";
-          }
-          (lib.optionalAttrs (audioCfg.enable && audioCfg.client.pipewireControl.enable) {
-            transport = {
-              name = audiovmName;
-              addr = hosts.${audiovmName}.ipv4;
-              inherit (audioCfg.server.pipewireForwarding) port;
-              protocol = "tcp";
-            };
-            inherit (audioCfg.client.pipewireControl) socket;
-          })
-        ];
-      eventProxy = [
-        {
-          transport = {
-            name = guivmName;
-            addr = hosts.${guivmName}.ipv4;
-            port = "9012";
-            protocol = "tcp";
-          };
-          producer = false;
-        }
-      ];
     };
     systemd.services.dbus-proxy-networkmanager = {
       description = "DBus proxy for Network Manager ${guivmName}";

--- a/modules/givc/host.nix
+++ b/modules/givc/host.nix
@@ -26,36 +26,48 @@ in
     givc.host = {
       enable = true;
       inherit (config.ghaf.givc) debug;
-      transport = {
-        name = config.networking.hostName;
-        addr = config.ghaf.networking.hosts.${config.networking.hostName}.ipv4;
-        port = "9000";
+      network = {
+        agent.transport = {
+          name = config.networking.hostName;
+          addr = config.ghaf.networking.hosts.${config.networking.hostName}.ipv4;
+          port = "9000";
+        };
+        admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
+        tls = {
+          enable = config.ghaf.givc.tls.mode != "none";
+          inherit (config.ghaf.givc.tls) mode;
+          spiffeEndpoint = config.ghaf.givc.tls.spiffeSocketPath;
+          inherit (config.ghaf.givc.tls) trustDomain;
+          inherit (config.ghaf.givc.tls) allowedIDs;
+        };
       };
-      services = [
-        "reboot.target"
-        "poweroff.target"
-        "suspend.target"
-      ]
-      ++ optionals config.ghaf.services.performance.host.tuned.enable [
-        "host-powersave.service"
-        "host-balanced.service"
-        "host-performance.service"
-        "host-powersave-battery.service"
-        "host-balanced-battery.service"
-        "host-performance-battery.service"
-      ];
-      adminVm = optionalString (
-        config.ghaf.common.adminHost != null
-      ) "microvm@${config.ghaf.common.adminHost}.service";
-      systemVms = map (vmName: "microvm@${vmName}.service") config.ghaf.common.systemHosts;
-      appVms = map (vmName: "microvm@${vmName}.service") config.ghaf.common.appHosts;
-      tls.enable = config.ghaf.givc.enableTls;
-      admin = lib.head config.ghaf.givc.adminConfig.addresses;
-      enableExecModule = true;
+      capabilities = {
+        services = [
+          "reboot.target"
+          "poweroff.target"
+          "suspend.target"
+        ]
+        ++ optionals config.ghaf.services.performance.host.tuned.enable [
+          "host-powersave.service"
+          "host-balanced.service"
+          "host-performance.service"
+          "host-powersave-battery.service"
+          "host-balanced-battery.service"
+          "host-performance-battery.service"
+        ];
+        vmServices = {
+          adminVm = optionalString (
+            config.ghaf.common.adminHost != null
+          ) "microvm@${config.ghaf.common.adminHost}.service";
+          systemVms = map (vmName: "microvm@${vmName}.service") config.ghaf.common.systemHosts;
+          appVms = map (vmName: "microvm@${vmName}.service") config.ghaf.common.appHosts;
+        };
+        exec.enable = true;
+      };
     };
 
     givc.tls = {
-      enable = config.ghaf.givc.enableTls;
+      enable = config.ghaf.givc.tls.mode == "static";
       agents = lib.attrsets.mapAttrsToList (n: v: {
         name = n;
         addr = v.ipv4;

--- a/modules/givc/netvm.nix
+++ b/modules/givc/netvm.nix
@@ -15,6 +15,11 @@ let
   guivmName = "gui-vm";
   inherit (config.ghaf.networking) hosts;
   inherit (config.networking) hostName;
+  tlsMode = config.ghaf.global-config.givc.tls.mode or config.ghaf.givc.tls.mode;
+  tlsSpiffeSocketPath =
+    config.ghaf.global-config.givc.tls.spiffeSocketPath or config.ghaf.givc.tls.spiffeSocketPath;
+  tlsTrustDomain = config.ghaf.global-config.givc.tls.trustDomain or config.ghaf.givc.tls.trustDomain;
+  tlsAllowedIDs = config.ghaf.global-config.givc.tls.allowedIDs or config.ghaf.givc.tls.allowedIDs;
 in
 {
   _file = ./netvm.nix;
@@ -28,41 +33,54 @@ in
     givc.sysvm = {
       enable = true;
       inherit (config.ghaf.givc) debug;
-      transport = {
-        name = config.networking.hostName;
-        addr = hosts.${hostName}.ipv4;
-        port = "9000";
+      network = {
+        agent.transport = {
+          name = config.networking.hostName;
+          addr = hosts.${hostName}.ipv4;
+          port = "9000";
+        };
+        admin.transport = lib.head config.ghaf.givc.adminConfig.addresses;
+        tls = {
+          enable = tlsMode != "none";
+          mode = tlsMode;
+          spiffeEndpoint = tlsSpiffeSocketPath;
+          trustDomain = tlsTrustDomain;
+          allowedIDs = tlsAllowedIDs;
+        };
       };
-      services = [
-        "poweroff.target"
-        "reboot.target"
-      ]
-      ++ optionals config.ghaf.services.power-manager.vm.enable [
-        "suspend.target"
-        "systemd-suspend.service"
-      ]
-      ++ optionals config.ghaf.services.performance.net.tuned.enable [
-        "net-powersave.service"
-        "net-balanced.service"
-        "net-performance.service"
-        "net-powersave-battery.service"
-        "net-balanced-battery.service"
-        "net-performance-battery.service"
-      ];
-      hwidService = true;
-      tls.enable = config.ghaf.givc.enableTls;
-      admin = lib.head config.ghaf.givc.adminConfig.addresses;
-      socketProxy = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
-        {
-          transport = {
-            name = guivmName;
-            addr = hosts.${guivmName}.ipv4;
-            port = "9010";
-            protocol = "tcp";
-          };
-          socket = "/tmp/dbusproxy_net.sock";
-        }
-      ];
+      capabilities = {
+        services = [
+          "poweroff.target"
+          "reboot.target"
+        ]
+        ++ optionals config.ghaf.services.power-manager.vm.enable [
+          "suspend.target"
+          "systemd-suspend.service"
+        ]
+        ++ optionals config.ghaf.services.performance.net.tuned.enable [
+          "net-powersave.service"
+          "net-balanced.service"
+          "net-performance.service"
+          "net-powersave-battery.service"
+          "net-balanced-battery.service"
+          "net-performance-battery.service"
+        ];
+        hwid.enable = true;
+        socketProxy = {
+          sockets = lib.optionals (builtins.elem guivmName config.ghaf.common.vms) [
+            {
+              transport = {
+                name = guivmName;
+                addr = hosts.${guivmName}.ipv4;
+                port = "9010";
+                protocol = "tcp";
+              };
+              socket = "/tmp/dbusproxy_net.sock";
+            }
+          ];
+          enable = builtins.elem guivmName config.ghaf.common.vms;
+        };
+      };
     };
     givc.dbusproxy = {
       enable = true;

--- a/modules/microvm/common/storagevm.nix
+++ b/modules/microvm/common/storagevm.nix
@@ -263,7 +263,7 @@ in
       # Remove systemd-machine-id-commit service
       systemd.suppressedSystemUnits = [ "systemd-machine-id-commit.service" ];
     })
-    (lib.mkIf (config.ghaf.givc.enable && config.ghaf.givc.enableTls) {
+    (lib.mkIf (config.ghaf.givc.enable && (config.ghaf.global-config.givc.enableTls or false)) {
       virtualisation.fileSystems.${cfg.mountPath} = {
         device = "/dev/disk/by-label/givc-${cfg.name}";
       };

--- a/modules/microvm/host/boot.nix
+++ b/modules/microvm/host/boot.nix
@@ -21,6 +21,7 @@ let
     ;
   inherit (config.ghaf.networking) hosts;
   inherit (config.ghaf.virtualization.microvm) appvm;
+  staticGivcTls = config.ghaf.givc.tls.mode == "static";
 
   # Filter system and enabled app VMs
   appVms = lib.attrNames (filterAttrs (_: vm: vm.enable) appvm.vms);
@@ -159,7 +160,7 @@ in
             # Wait for gui-vm to reach multi-user.target. Times out after 60 seconds
             wait-for-ui = {
               description = "Wait for GuiVM startup";
-              after = [ "givc-key-setup.service" ];
+              after = lib.optionals staticGivcTls [ "givc-key-setup.service" ];
               serviceConfig = {
                 Type = "oneshot";
                 ExecStart = ''
@@ -177,10 +178,7 @@ in
             # after user has logged in and ghaf-session is active. Times out after 120 seconds
             wait-for-login = {
               description = "Wait for user login to gui-vm";
-              after = [
-                "givc-key-setup.service"
-                "system-ui.target"
-              ];
+              after = lib.optionals staticGivcTls [ "givc-key-setup.service" ] ++ [ "system-ui.target" ];
               serviceConfig = {
                 Type = "oneshot";
                 ExecStart = ''

--- a/modules/microvm/host/microvm-host.nix
+++ b/modules/microvm/host/microvm-host.nix
@@ -284,9 +284,11 @@ in
             vmConfig != null
             && lib.hasAttr "ghaf" vmConfig
             && lib.hasAttr "givc" vmConfig.ghaf
+            && lib.hasAttr "global-config" vmConfig.ghaf
+            && lib.hasAttr "givc" vmConfig.ghaf.global-config
             && lib.hasAttr "storagevm" vmConfig.ghaf
             && (vmConfig.ghaf.givc.enable or false)
-            && (vmConfig.ghaf.givc.enableTls or false)
+            && (vmConfig.ghaf.global-config.givc.enableTls or false)
             && (vmConfig.ghaf.storagevm.enable or false)
           ) config.microvm.vms;
 

--- a/modules/microvm/sysvms/adminvm-base.nix
+++ b/modules/microvm/sysvms/adminvm-base.nix
@@ -161,6 +161,7 @@ in
     givc = {
       inherit (globalConfig.givc) enable;
       inherit (globalConfig.givc) debug;
+      tls = hostConfig.givc.tls or { };
     };
 
     # Security

--- a/modules/microvm/sysvms/appvm-base.nix
+++ b/modules/microvm/sysvms/appvm-base.nix
@@ -142,6 +142,7 @@ in
         givc = {
           enable = globalConfig.givc.enable or false;
           debug = globalConfig.givc.debug or false;
+          tls = hostConfig.givc.tls or { };
         };
         givc.appvm = {
           enable = true;

--- a/modules/microvm/sysvms/audiovm-base.nix
+++ b/modules/microvm/sysvms/audiovm-base.nix
@@ -226,6 +226,7 @@ in
     givc = {
       enable = globalConfig.givc.enable or false;
       debug = globalConfig.givc.debug or false;
+      tls = hostConfig.givc.tls or { };
     };
 
     # Security - from globalConfig

--- a/modules/microvm/sysvms/guivm-base.nix
+++ b/modules/microvm/sysvms/guivm-base.nix
@@ -134,6 +134,7 @@ in
     givc = {
       enable = globalConfig.givc.enable or false;
       debug = globalConfig.givc.debug or false;
+      tls = hostConfig.givc.tls or { };
     };
     givc.guivm.enable = true;
 

--- a/modules/microvm/sysvms/netvm-base.nix
+++ b/modules/microvm/sysvms/netvm-base.nix
@@ -89,6 +89,7 @@ in
     givc = {
       enable = globalConfig.givc.enable or false;
       debug = globalConfig.givc.debug or false;
+      tls = hostConfig.givc.tls or { };
     };
     givc.netvm.enable = true;
 

--- a/targets/laptop/flake-module.nix
+++ b/targets/laptop/flake-module.nix
@@ -205,6 +205,10 @@ let
       extraConfig = {
         reference.profiles.mvp-user-trial.enable = true;
         partitioning.disko.enable = true;
+        givc.tls.mode = "spiffe";
+        givc.tls.trustDomain = "ghaf.internal";
+        global-config.spiffe.enable = true;
+        global-config.spiffe.trustDomain = "ghaf.internal";
       };
     })
 


### PR DESCRIPTION
## Summary
- switch Ghaf GIVC integration to SPIFFE-capable `ghaf-givc` and pin input to `vadika/ghaf-givc` branch used in tiiuae/ghaf-givc#369
- propagate GIVC TLS mode and SPIFFE settings through host and VM composition paths so host, admin-vm, and sys/app VMs all run with `mode=spiffe`
- remove static-certificate boot coupling in SPIFFE mode, fix microVM startup ordering dependencies, and add comprehensive docs for SPIFFE GIVC certificate distribution

## Validation
- `nix fmt -- --fail-on-change`
- `nix eval .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug.drvPath --option eval-cache false`
- `nix build .#doc --no-link`
- runtime verification on flashed `#lenovo-x1-carbon-gen11-debug`:
  - host/net-vm/admin-vm `/etc/givc-agent/config.json` report `network.tls.mode = spiffe`
  - `givc-ghaf-host.service`, `givc-net-vm.service`, `givc-admin.service`, and `givc-admin-vm.service` active